### PR TITLE
fix: stabilize macOS traffic light button positioning and sizing

### DIFF
--- a/build/darwin/Info.dev.plist
+++ b/build/darwin/Info.dev.plist
@@ -18,7 +18,7 @@
         <key>CFBundleIconFile</key>
         <string>iconfile</string>
         <key>LSMinimumSystemVersion</key>
-        <string>10.13.0</string>
+        <string>15.0</string>
         <key>NSHighResolutionCapable</key>
         <string>true</string>
         <key>NSHumanReadableCopyright</key>

--- a/build/darwin/Info.plist
+++ b/build/darwin/Info.plist
@@ -18,7 +18,7 @@
         <key>CFBundleIconFile</key>
         <string>iconfile</string>
         <key>LSMinimumSystemVersion</key>
-        <string>10.13.0</string>
+        <string>15.0</string>
         <key>NSHighResolutionCapable</key>
         <string>true</string>
         <key>NSHumanReadableCopyright</key>

--- a/build/darwin/Taskfile.yml
+++ b/build/darwin/Taskfile.yml
@@ -55,9 +55,9 @@ tasks:
       GOOS: darwin
       CGO_ENABLED: 1
       GOARCH: '{{.ARCH | default ARCH}}'
-      CGO_CFLAGS: "-mmacosx-version-min=12.0"
-      CGO_LDFLAGS: "-mmacosx-version-min=12.0"
-      MACOSX_DEPLOYMENT_TARGET: "12.0"
+      CGO_CFLAGS: "-mmacosx-version-min=15.0"
+      CGO_LDFLAGS: "-mmacosx-version-min=15.0"
+      MACOSX_DEPLOYMENT_TARGET: "15.0"
 
   build:docker:
     summary: Cross-compiles for macOS using Docker (for Linux/Windows hosts)

--- a/flake.nix
+++ b/flake.nix
@@ -26,15 +26,17 @@
           ];
 
           # 開発に必要なパッケージ群
-          # macOS: Cocoa/WebKit等のフレームワークはデフォルトSDKに含まれるため明示不要
           buildInputs = with pkgs; [
-            go_1_25     # バックエンド用 (go.mod は go 1.23 だが後方互換)
+            go_1_25     # バックエンド用
             nodejs_22   # フロントエンド用 (LTS)
+          ] ++ lib.optionals stdenv.isDarwin [
+            apple-sdk_15  # macOS 15+ SDK — Cocoa/WebKit フレームワーク含む
           ] ++ linuxDeps;
 
           # 環境に入った時に実行されるフック
           shellHook = ''
             export CGO_ENABLED=1
+            export MACOSX_DEPLOYMENT_TARGET=15.0
             export PATH=$PATH:$(go env GOPATH)/bin
             
             # wails3 コマンドがなければインストール

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
 
           # 開発に必要なパッケージ群
           buildInputs = with pkgs; [
-            go_1_25     # バックエンド用
+            go_1_25     # バックエンド用 (go.mod は go 1.23 だが後方互換)
             nodejs_22   # フロントエンド用 (LTS)
           ] ++ lib.optionals stdenv.isDarwin [
             apple-sdk_15  # macOS 15+ SDK — Cocoa/WebKit フレームワーク含む

--- a/main.go
+++ b/main.go
@@ -67,13 +67,12 @@ func main() {
 	})
 	app.Menu.SetApplicationMenu(buildMenu(appStruct))
 
-
 	app.Window.NewWithOptions(application.WebviewWindowOptions{
 		Title:  "ExifFrame",
 		Width:  1024,
 		Height: 768,
 		Mac: application.MacWindow{
-			TitleBar: application.MacTitleBarHiddenInset,
+			TitleBar: application.MacTitleBarHiddenInsetUnified,
 		},
 		BackgroundColour: application.NewRGB(27, 38, 54),
 		URL:              "/",


### PR DESCRIPTION
- Use MacTitleBarHiddenInsetUnified to explicitly set toolbar style, eliminating layout ambiguity from NSWindowToolbarStyleAutomatic
- Raise minimum deployment target to macOS 15.0 (Sequoia)
- Add apple-sdk_15 to Nix buildInputs and set MACOSX_DEPLOYMENT_TARGET=15.0 in shellHook to ensure consistent native UI rendering across environments

resolved #21 
