### PR TITLE
Fix: Updated Ubuntu Runner to 24.04 to support GTK 4.10+

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             artifact: ExifFrame-linux-amd64.tar.gz
           - os: windows-2022
             artifact: ExifFrame-windows-amd64.exe


### PR DESCRIPTION
ubuntu runnerのバージョンが低くてビルドが通らない問題を解決する