### PR TITLE
feat: separate auto-export settings and redesign settings window

### DIFF
--- a/app.go
+++ b/app.go
@@ -504,8 +504,8 @@ func (a *App) OpenSettingsWindow() {
 	app.Window.NewWithOptions(application.WebviewWindowOptions{
 		Name:  "settings",
 		Title: "Preferences",
-		Width: 600,
-		Height: 500,
+		Width: 800,
+		Height: 600,
 		Mac: application.MacWindow{
 			TitleBar: application.MacTitleBarHiddenInsetUnified,
 		},

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -12,6 +12,7 @@
     --border-color: #3e3e42;
     --input-bg: #1e1e1e;
     --input-border: #3e3e42;
+    --bg-button-hover: rgba(255, 255, 255, 0.05);
 }
 
 body {
@@ -323,19 +324,23 @@ body {
         opacity: 0;
         transform: translateY(10px);
     }
+
     10% {
         opacity: 1;
         transform: translateY(0);
     }
+
     90% {
         opacity: 1;
         transform: translateY(0);
     }
+
     100% {
         opacity: 0;
         transform: translateY(-10px);
     }
 }
+
 /* Segmented Control */
 .segmented-control {
     display: flex;
@@ -496,4 +501,30 @@ body {
 
 .metadata-settings-header .segment {
     padding: 4px 8px;
+}
+
+/* Settings Nav Button */
+.nav-btn {
+    width: 100%;
+    text-align: left;
+    padding: 0.8rem 1rem;
+    margin-bottom: 0.5rem;
+    border: none;
+    border-radius: 6px;
+    background-color: transparent;
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 0.9rem;
+    font-weight: 400;
+    transition: all 0.2s ease;
+}
+
+.nav-btn:hover {
+    background-color: var(--bg-button-hover);
+}
+
+.nav-btn.active {
+    background-color: var(--bg-button-hover);
+    color: var(--text-primary);
+    font-weight: 600;
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,54 +1,12 @@
-import { useState, useRef, useEffect, useCallback, ChangeEvent } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import './App.css';
 // @ts-expect-error generated bindings does not provide declaration files for JS module
 import { App as AppAPI, Settings } from '../bindings/ExifFrame/index';
 import { Window, Events, System, Call } from '@wailsio/runtime';
 
-interface ExifData {
-    camera: string;
-    lens: string;
-    focalLength: string;
-    aperture: string;
-    shutterSpeed: string;
-    iso: string;
-    film: string;
-    developer: string;
-    dilution: string;
-    temperature: string;
-    time: string;
-}
-
-interface MetadataVisibility {
-    camera: boolean;
-    lens: boolean;
-    focalLength: boolean;
-    aperture: boolean;
-    shutterSpeed: boolean;
-    iso: boolean;
-    film: boolean;
-    developer: boolean;
-    dilution: boolean;
-    temperature: boolean;
-    time: boolean;
-}
-
-const VISIBILITY_KEYS = [
-    'camera', 'lens', 'focalLength', 'aperture', 'shutterSpeed', 'iso',
-    'film', 'developer', 'dilution', 'temperature', 'time',
-] as const;
-
-const settingsKey = (k: typeof VISIBILITY_KEYS[number]) =>
-    k === 'iso' ? 'visibilityISO' : `visibility${k.charAt(0).toUpperCase()}${k.slice(1)}`;
-
-function toVisibility(s: any): MetadataVisibility {
-    return Object.fromEntries(
-        VISIBILITY_KEYS.map(k => [k, (s[settingsKey(k)] as boolean) ?? true])
-    ) as unknown as MetadataVisibility;
-}
-
-function applyVisibility(s: any, v: MetadataVisibility): void {
-    VISIBILITY_KEYS.forEach(k => { s[settingsKey(k)] = v[k]; });
-}
+import { ExifData, MetadataVisibility, toVisibility, applyVisibility } from './types';
+import { FrameSettingsPanel } from './components/FrameSettingsPanel';
+import { MetadataSettingsPanel } from './components/MetadataSettingsPanel';
 
 const TOAST_DURATION_MS = 3000;
 
@@ -195,49 +153,6 @@ function renderImageToCanvas(
     ctx.lineWidth = Math.max(1, Math.floor(baseScale * 0.0015));
     ctx.stroke();
 }
-
-const EyeIcon = ({ visible }: { visible: boolean }) => (
-    visible ? (
-        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path><circle cx="12" cy="12" r="3"></circle></svg>
-    ) : (
-        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path><line x1="1" y1="1" x2="23" y2="23"></line></svg>
-    )
-);
-
-interface ToggleInputProps {
-    label: string;
-    id: string;
-    value: string;
-    onChange: (e: ChangeEvent<HTMLInputElement>) => void;
-    visible: boolean;
-    onToggleVisibility: () => void;
-}
-
-const ToggleInput = ({ label, id, value, onChange, visible, onToggleVisibility }: ToggleInputProps) => (
-    <div className="input-group">
-        <div className="toggle-input-header">
-            <label htmlFor={id} className="toggle-input-label">{label}</label>
-            <button
-                type="button"
-                onClick={onToggleVisibility}
-                className={`toggle-visibility-btn ${visible ? 'visible' : ''}`}
-                title={visible ? `Hide ${label} from frame` : `Show ${label} on frame`}
-                aria-label={visible ? `Hide ${label} from frame` : `Show ${label} on frame`}
-                aria-pressed={visible}
-            >
-                <EyeIcon visible={visible} />
-            </button>
-        </div>
-        <input
-            id={id}
-            type="text"
-            value={value}
-            onChange={onChange}
-            className={`toggle-input-field ${!visible ? 'hidden' : ''}`}
-        />
-    </div>
-);
-
 interface ProcessFileResult {
     imageURL?: string;
     camera?: string;
@@ -287,13 +202,19 @@ function App() {
                 const img = new Image();
                 img.onload = async () => {
                     const offscreenCanvas = document.createElement('canvas');
+
+                    const override = currentSet.overrideExif;
+                    
+                    const pick = (settingsVal: string | undefined, exifVal: string | undefined) => 
+                        override && settingsVal ? settingsVal : exifVal || "";
+
                     const exifData = {
-                        camera: result.camera || "",
-                        lens: result.lens || "",
-                        focalLength: result.focalLength || "",
-                        aperture: result.aperture || "",
-                        shutterSpeed: result.shutterSpeed || "",
-                        iso: result.iso || "",
+                        camera: pick(currentSet.camera, result.camera),
+                        lens: pick(currentSet.lens, result.lens),
+                        focalLength: pick(currentSet.focalLength, result.focalLength),
+                        aperture: pick(currentSet.aperture, result.aperture),
+                        shutterSpeed: pick(currentSet.shutterSpeed, result.shutterSpeed),
+                        iso: pick(currentSet.iso, result.iso),
                         film: currentSet.film || "",
                         developer: currentSet.developer || "",
                         dilution: currentSet.dilution || "",
@@ -489,48 +410,53 @@ function App() {
             unsubSettings();
         };
     }, []);
+    const handleSaveAutoExportDefault = async () => {
+        const s = new Settings();
+        s.watchFolder = watchFolder;
+        s.exportFolder = exportFolder;
+        s.aspectRatioPreset = aspectRatioPreset;
+        s.customRatioW = customRatioW;
+        s.customRatioH = customRatioH;
+        s.orientation = orientation;
+        s.alignment = alignment;
+        s.showPipeSeparator = showPipeSeparator;
+        s.profile = profile;
+        // In App.tsx (manual view), we don't have an overrideExif toggle. 
+        // We probably shouldn't overwrite overrideExif if we don't have it in state,
+        // so let's preserve it from the current global settings before saving.
 
-    // Save settings when aspect ratio etc changes
-    useEffect(() => {
-        if (isInitialLoad.current) return;
+        try {
+            const currentSettings = await AppAPI.GetSettings();
+            s.overrideExif = currentSettings.overrideExif;
+        } catch (e) {
+            s.overrideExif = false;
+        }
 
-        const saveCurrentSettings = async () => {
-            const s = new Settings();
-            s.watchFolder = watchFolder;
-            s.exportFolder = exportFolder;
-            s.aspectRatioPreset = aspectRatioPreset;
-            s.customRatioW = customRatioW;
-            s.customRatioH = customRatioH;
-            s.orientation = orientation;
-            s.alignment = alignment;
-            s.showPipeSeparator = showPipeSeparator;
-            s.profile = profile;
-            s.film = exif.film;
-            s.developer = exif.developer;
-            s.dilution = exif.dilution;
-            s.temperature = exif.temperature;
-            s.time = exif.time;
+        s.camera = exif.camera;
+        s.lens = exif.lens;
+        s.focalLength = exif.focalLength;
+        s.aperture = exif.aperture;
+        s.shutterSpeed = exif.shutterSpeed;
+        s.iso = exif.iso;
+        s.film = exif.film;
+        s.developer = exif.developer;
+        s.dilution = exif.dilution;
+        s.temperature = exif.temperature;
+        s.time = exif.time;
 
-            applyVisibility(s, visibility);
+        applyVisibility(s, visibility);
 
-            try {
-                const errStr = await AppAPI.SaveSettings(s);
-                if (errStr && errStr !== "") {
-                    showToast(errStr);
-                } else {
-                    showToast("Settings saved");
-                }
-            } catch (e: any) {
-                showToast("Error saving settings");
+        try {
+            const errStr = await AppAPI.SaveSettings(s);
+            if (errStr && errStr !== "") {
+                showToast(errStr);
+            } else {
+                showToast("Auto-export default saved");
             }
-        };
-
-        // Debounce saving settings when UI changes
-        const t = setTimeout(() => {
-            saveCurrentSettings();
-        }, 500);
-        return () => clearTimeout(t);
-    }, [aspectRatioPreset, customRatioW, customRatioH, orientation, alignment, showPipeSeparator, watchFolder, exportFolder, profile, exif.film, exif.developer, exif.dilution, exif.temperature, exif.time, visibility.camera, visibility.lens, visibility.focalLength, visibility.aperture, visibility.shutterSpeed, visibility.iso, visibility.film, visibility.developer, visibility.dilution, visibility.temperature, visibility.time]);
+        } catch (e: any) {
+            showToast("Error saving settings");
+        }
+    };
 
     useEffect(() => {
         setIsMac(System.IsMac());
@@ -755,247 +681,31 @@ function App() {
 
                 {imageLoaded && (
                     <aside className="sidebar">
-                        <div className="sidebar-section frame-settings-section">
-                            <h3>Frame Settings</h3>
-                            <div className="input-group">
-                                <label htmlFor="aspect-ratio-preset">Aspect Ratio</label>
-                                <select
-                                    id="aspect-ratio-preset"
-                                    value={aspectRatioPreset}
-                                    onChange={(e) => setAspectRatioPreset(e.target.value)}
-                                >
-                                    <option value="4300:3618">Default (4300:3618)</option>
-                                    <option value="1:1">Square (1:1)</option>
-                                    <option value="3:2">3:2</option>
-                                    <option value="4:3">4:3</option>
-                                    <option value="16:9">16:9</option>
-                                    <option value="custom">Custom</option>
-                                </select>
-                            </div>
-                            {aspectRatioPreset === "custom" && (
-                                <div className="input-row">
-                                    <div className="input-group">
-                                        <label htmlFor="custom-ratio-w">Width</label>
-                                        <input
-                                            id="custom-ratio-w"
-                                            type="number"
-                                            value={customRatioW || ''}
-                                            onChange={e => setCustomRatioW(Number(e.target.value) || 0)}
-                                            min="1"
-                                        />
-                                    </div>
-                                    <div className="input-group">
-                                        <label htmlFor="custom-ratio-h">Height</label>
-                                        <input
-                                            id="custom-ratio-h"
-                                            type="number"
-                                            value={customRatioH || ''}
-                                            onChange={e => setCustomRatioH(Number(e.target.value) || 0)}
-                                            min="1"
-                                        />
-                                    </div>
-                                </div>
-                            )}
-                            <div className="input-group">
-                                <label>Orientation</label>
-                                <div className={`segmented-control ${aspectRatioPreset === '1:1' ? 'disabled' : ''}`}>
-                                    <button
-                                        type="button"
-                                        className={`segment ${orientation === 'landscape' ? 'active' : ''}`}
-                                        onClick={() => setOrientation('landscape')}
-                                        disabled={aspectRatioPreset === '1:1'}
-                                        aria-pressed={orientation === 'landscape'}
-                                    >
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="3" y="5" width="18" height="14" rx="2" ry="2"></rect></svg>
-                                        Landscape
-                                    </button>
-                                    <button
-                                        type="button"
-                                        className={`segment ${orientation === 'portrait' ? 'active' : ''}`}
-                                        onClick={() => setOrientation('portrait')}
-                                        disabled={aspectRatioPreset === '1:1'}
-                                        aria-pressed={orientation === 'portrait'}
-                                    >
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="5" y="3" width="14" height="18" rx="2" ry="2"></rect></svg>
-                                        Portrait
-                                    </button>
-                                </div>
-                            </div>
-                            <div className="input-group">
-                                <label>Vertical Alignment</label>
-                                <div className="segmented-control">
-                                    <button
-                                        type="button"
-                                        className={`segment ${alignment === 'top' ? 'active' : ''}`}
-                                        onClick={() => setAlignment('top')}
-                                        aria-pressed={alignment === 'top'}
-                                    >
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="4" y1="4" x2="20" y2="4"></line><rect x="8" y="8" width="8" height="8" rx="1" ry="1"></rect></svg>
-                                        Top
-                                    </button>
-                                    <button
-                                        type="button"
-                                        className={`segment ${alignment === 'center' ? 'active' : ''}`}
-                                        onClick={() => setAlignment('center')}
-                                        aria-pressed={alignment === 'center'}
-                                    >
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="4" y1="12" x2="20" y2="12"></line><rect x="8" y="8" width="8" height="8" rx="1" ry="1"></rect></svg>
-                                        Center
-                                    </button>
-                                </div>
-                            </div>
-                            <div className="input-group">
-                                <label>Separator Style</label>
-                                <div className="segmented-control">
-                                    <button
-                                        type="button"
-                                        className={`segment ${showPipeSeparator ? 'active' : ''}`}
-                                        onClick={() => setShowPipeSeparator(true)}
-                                        aria-pressed={showPipeSeparator}
-                                    >
-                                        Pipe (|)
-                                    </button>
-                                    <button
-                                        type="button"
-                                        className={`segment ${!showPipeSeparator ? 'active' : ''}`}
-                                        onClick={() => setShowPipeSeparator(false)}
-                                        aria-pressed={!showPipeSeparator}
-                                    >
-                                        Space
-                                    </button>
-                                </div>
-                            </div>
-                        </div>
+                        <FrameSettingsPanel
+                            aspectRatioPreset={aspectRatioPreset} setAspectRatioPreset={setAspectRatioPreset}
+                            customRatioW={customRatioW} setCustomRatioW={setCustomRatioW}
+                            customRatioH={customRatioH} setCustomRatioH={setCustomRatioH}
+                            orientation={orientation} setOrientation={setOrientation}
+                            alignment={alignment} setAlignment={setAlignment}
+                            showPipeSeparator={showPipeSeparator} setShowPipeSeparator={setShowPipeSeparator}
+                        />
 
-                        <div className="sidebar-section metadata-settings-section">
-                            <div className="metadata-settings-header">
-                                <h3>Metadata Settings</h3>
-                                <div className="segmented-control">
-                                    <button
-                                        type="button"
-                                        className={`segment ${profile === 'digital' ? 'active' : ''}`}
-                                        onClick={() => setProfile('digital')}
-                                        aria-pressed={profile === 'digital'}
-                                    >
-                                        Digital
-                                    </button>
-                                    <button
-                                        type="button"
-                                        className={`segment ${profile === 'film' ? 'active' : ''}`}
-                                        onClick={() => setProfile('film')}
-                                        aria-pressed={profile === 'film'}
-                                    >
-                                        Film
-                                    </button>
-                                </div>
-                            </div>
+                        <MetadataSettingsPanel
+                            profile={profile} setProfile={setProfile}
+                            exif={exif} setExif={setExif}
+                            visibility={visibility} setVisibility={setVisibility}
+                        />
 
-                            <ToggleInput
-                                label="Camera"
-                                id="camera-input"
-                                value={exif.camera}
-                                onChange={(e) => setExif(prev => ({ ...prev, camera: e.target.value }))}
-                                visible={visibility.camera}
-                                onToggleVisibility={() => setVisibility(prev => ({ ...prev, camera: !prev.camera }))}
-                            />
-                            <ToggleInput
-                                label="Lens"
-                                id="lens-input"
-                                value={exif.lens}
-                                onChange={(e) => setExif(prev => ({ ...prev, lens: e.target.value }))}
-                                visible={visibility.lens}
-                                onToggleVisibility={() => setVisibility(prev => ({ ...prev, lens: !prev.lens }))}
-                            />
-
-                            <div className="input-row">
-                                <ToggleInput
-                                    label="Focal Length"
-                                    id="focalLength-input"
-                                    value={exif.focalLength}
-                                    onChange={(e) => setExif(prev => ({ ...prev, focalLength: e.target.value }))}
-                                    visible={visibility.focalLength}
-                                    onToggleVisibility={() => setVisibility(prev => ({ ...prev, focalLength: !prev.focalLength }))}
-                                />
-                                <ToggleInput
-                                    label="Aperture"
-                                    id="aperture-input"
-                                    value={exif.aperture}
-                                    onChange={(e) => setExif(prev => ({ ...prev, aperture: e.target.value }))}
-                                    visible={visibility.aperture}
-                                    onToggleVisibility={() => setVisibility(prev => ({ ...prev, aperture: !prev.aperture }))}
-                                />
-                            </div>
-
-                            <div className="input-row">
-                                <ToggleInput
-                                    label="Shutter Speed"
-                                    id="shutterSpeed-input"
-                                    value={exif.shutterSpeed}
-                                    onChange={(e) => setExif(prev => ({ ...prev, shutterSpeed: e.target.value }))}
-                                    visible={visibility.shutterSpeed}
-                                    onToggleVisibility={() => setVisibility(prev => ({ ...prev, shutterSpeed: !prev.shutterSpeed }))}
-                                />
-                                {profile === 'digital' ? (
-                                    <ToggleInput
-                                        label="ISO"
-                                        id="iso-input"
-                                        value={exif.iso}
-                                        onChange={(e) => setExif(prev => ({ ...prev, iso: e.target.value }))}
-                                        visible={visibility.iso}
-                                        onToggleVisibility={() => setVisibility(prev => ({ ...prev, iso: !prev.iso }))}
-                                    />
-                                ) : (
-                                    <ToggleInput
-                                        label="Film"
-                                        id="film-input"
-                                        value={exif.film}
-                                        onChange={(e) => setExif(prev => ({ ...prev, film: e.target.value }))}
-                                        visible={visibility.film}
-                                        onToggleVisibility={() => setVisibility(prev => ({ ...prev, film: !prev.film }))}
-                                    />
-                                )}
-                            </div>
-
-                            {profile === 'film' && (
-                                <>
-                                    <div className="input-row">
-                                        <ToggleInput
-                                            label="Developer"
-                                            id="developer-input"
-                                            value={exif.developer}
-                                            onChange={(e) => setExif(prev => ({ ...prev, developer: e.target.value }))}
-                                            visible={visibility.developer}
-                                            onToggleVisibility={() => setVisibility(prev => ({ ...prev, developer: !prev.developer }))}
-                                        />
-                                        <ToggleInput
-                                            label="Dilution"
-                                            id="dilution-input"
-                                            value={exif.dilution}
-                                            onChange={(e) => setExif(prev => ({ ...prev, dilution: e.target.value }))}
-                                            visible={visibility.dilution}
-                                            onToggleVisibility={() => setVisibility(prev => ({ ...prev, dilution: !prev.dilution }))}
-                                        />
-                                    </div>
-                                    <div className="input-row">
-                                        <ToggleInput
-                                            label="Temperature"
-                                            id="temperature-input"
-                                            value={exif.temperature}
-                                            onChange={(e) => setExif(prev => ({ ...prev, temperature: e.target.value }))}
-                                            visible={visibility.temperature}
-                                            onToggleVisibility={() => setVisibility(prev => ({ ...prev, temperature: !prev.temperature }))}
-                                        />
-                                        <ToggleInput
-                                            label="Time"
-                                            id="time-input"
-                                            value={exif.time}
-                                            onChange={(e) => setExif(prev => ({ ...prev, time: e.target.value }))}
-                                            visible={visibility.time}
-                                            onToggleVisibility={() => setVisibility(prev => ({ ...prev, time: !prev.time }))}
-                                        />
-                                    </div>
-                                </>
-                            )}
+                        <div className="sidebar-section default-settings-section" style={{ marginTop: 'auto', paddingTop: '1.5rem', borderTop: '1px solid var(--border-color)' }}>
+                            <button
+                                className="btn btn-primary"
+                                style={{ width: '100%', display: 'flex', justifyContent: 'center', alignItems: 'center', gap: '0.5rem' }}
+                                onClick={handleSaveAutoExportDefault}
+                                title="Save current settings as default for auto-processing"
+                            >
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"></path><polyline points="17 21 17 13 7 13 7 21"></polyline><polyline points="7 3 7 8 15 8"></polyline></svg>
+                                Save as Auto-Export Default
+                            </button>
                         </div>
                     </aside>
                 )}

--- a/frontend/src/SettingsWindow.tsx
+++ b/frontend/src/SettingsWindow.tsx
@@ -7,7 +7,7 @@ import { FrameSettingsPanel } from './components/FrameSettingsPanel';
 import { MetadataSettingsPanel } from './components/MetadataSettingsPanel';
 import { ExifData, MetadataVisibility, toVisibility, applyVisibility } from './types';
 
-const TOAST_DURATION_MS = 2500;
+const TOAST_DURATION_MS = 3000;
 
 function SettingsWindow() {
     const [activeTab, setActiveTab] = useState<'general' | 'frame' | 'metadata'>('general');
@@ -79,14 +79,14 @@ function SettingsWindow() {
     const loadSettings = (s: Settings) => {
         setWatchFolder(s.watchFolder || "");
         setExportFolder(s.exportFolder || "");
-        
+
         setAspectRatioPreset(s.aspectRatioPreset || "4300:3618");
         setCustomRatioW(s.customRatioW || 4300);
         setCustomRatioH(s.customRatioH || 3618);
         setOrientation(s.orientation || "landscape");
         setAlignment(s.alignment || "center");
         setShowPipeSeparator(s.showPipeSeparator ?? true);
-        
+
         setProfile(s.profile || "digital");
         setOverrideExif(s.overrideExif ?? false);
         setExif({
@@ -123,7 +123,7 @@ function SettingsWindow() {
 
     const handleSave = async () => {
         const s = new Settings();
-        
+
         s.watchFolder = watchFolder;
         s.exportFolder = exportFolder;
         s.aspectRatioPreset = aspectRatioPreset;
@@ -132,7 +132,7 @@ function SettingsWindow() {
         s.orientation = orientation;
         s.alignment = alignment;
         s.showPipeSeparator = showPipeSeparator;
-        
+
         s.profile = profile;
         s.overrideExif = overrideExif;
         s.camera = exif.camera;
@@ -159,7 +159,7 @@ function SettingsWindow() {
 
             // Notify other windows
             Events.Emit("settings_saved");
-            
+
             showToast("Settings saved successfully.");
         } catch (e: any) {
             console.error("Error saving settings", e);
@@ -264,11 +264,11 @@ function SettingsWindow() {
                 </div>
             )}
 
-            <footer style={{ 
-                padding: '1rem 2rem', 
-                borderTop: '1px solid var(--border-color)', 
-                display: 'flex', 
-                justifyContent: 'flex-end', 
+            <footer style={{
+                padding: '1rem 2rem',
+                borderTop: '1px solid var(--border-color)',
+                display: 'flex',
+                justifyContent: 'flex-end',
                 backgroundColor: 'var(--bg-panel)',
                 flexShrink: 0
             }}>

--- a/frontend/src/SettingsWindow.tsx
+++ b/frontend/src/SettingsWindow.tsx
@@ -1,32 +1,119 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import './App.css';
 // @ts-expect-error generated bindings does not provide declaration files for JS module
 import { App as AppAPI, Settings } from '../bindings/ExifFrame/index';
 import { Events, System } from '@wailsio/runtime';
+import { FrameSettingsPanel } from './components/FrameSettingsPanel';
+import { MetadataSettingsPanel } from './components/MetadataSettingsPanel';
+import { ExifData, MetadataVisibility, toVisibility, applyVisibility } from './types';
+
+const TOAST_DURATION_MS = 2500;
 
 function SettingsWindow() {
+    const [activeTab, setActiveTab] = useState<'general' | 'frame' | 'metadata'>('general');
+    const [isMac, setIsMac] = useState(false);
+
+    // Toast State
+    const [toastMessage, setToastMessage] = useState<string | null>(null);
+    const toastTimerRef = useRef<number | null>(null);
+    const toastRafRef = useRef<number | null>(null);
+
+    // Toast cleanup
+    useEffect(() => {
+        return () => {
+            if (toastTimerRef.current !== null) {
+                window.clearTimeout(toastTimerRef.current);
+            }
+            if (toastRafRef.current !== null) {
+                window.cancelAnimationFrame(toastRafRef.current);
+            }
+        };
+    }, []);
+
+    const showToast = (message: string) => {
+        if (toastTimerRef.current !== null) {
+            window.clearTimeout(toastTimerRef.current);
+            toastTimerRef.current = null;
+        }
+        if (toastRafRef.current !== null) {
+            window.cancelAnimationFrame(toastRafRef.current);
+            toastRafRef.current = null;
+        }
+
+        // Force a re-render by clearing the state first
+        setToastMessage(null);
+        toastRafRef.current = requestAnimationFrame(() => {
+            setToastMessage(message);
+            toastTimerRef.current = window.setTimeout(() => {
+                setToastMessage(null);
+                toastTimerRef.current = null;
+            }, TOAST_DURATION_MS);
+            toastRafRef.current = null;
+        });
+    };
+
+    // General
     const [watchFolder, setWatchFolder] = useState("");
     const [exportFolder, setExportFolder] = useState("");
-    const [fullSettings, setFullSettings] = useState<Settings | null>(null);
-    const [isMac, setIsMac] = useState(false);
+
+    // Frame Settings
+    const [aspectRatioPreset, setAspectRatioPreset] = useState<string>("4300:3618");
+    const [customRatioW, setCustomRatioW] = useState<number>(4300);
+    const [customRatioH, setCustomRatioH] = useState<number>(3618);
+    const [orientation, setOrientation] = useState<"landscape" | "portrait">("landscape");
+    const [alignment, setAlignment] = useState<"top" | "center">("center");
+    const [showPipeSeparator, setShowPipeSeparator] = useState<boolean>(true);
+
+    // Metadata Settings
+    const [profile, setProfile] = useState<string>("digital");
+    const [exif, setExif] = useState<ExifData>({
+        camera: "", lens: "", focalLength: "", aperture: "", shutterSpeed: "",
+        iso: "", film: "", developer: "", dilution: "", temperature: "", time: ""
+    });
+    const [visibility, setVisibility] = useState<MetadataVisibility>({
+        camera: true, lens: true, focalLength: true, aperture: true, shutterSpeed: true,
+        iso: true, film: true, developer: true, dilution: true, temperature: true, time: true
+    });
+    const [overrideExif, setOverrideExif] = useState<boolean>(false);
+
+    const loadSettings = (s: Settings) => {
+        setWatchFolder(s.watchFolder || "");
+        setExportFolder(s.exportFolder || "");
+        
+        setAspectRatioPreset(s.aspectRatioPreset || "4300:3618");
+        setCustomRatioW(s.customRatioW || 4300);
+        setCustomRatioH(s.customRatioH || 3618);
+        setOrientation(s.orientation || "landscape");
+        setAlignment(s.alignment || "center");
+        setShowPipeSeparator(s.showPipeSeparator ?? true);
+        
+        setProfile(s.profile || "digital");
+        setOverrideExif(s.overrideExif ?? false);
+        setExif({
+            camera: s.camera || "",
+            lens: s.lens || "",
+            focalLength: s.focalLength || "",
+            aperture: s.aperture || "",
+            shutterSpeed: s.shutterSpeed || "",
+            iso: s.iso || "",
+            film: s.film || "",
+            developer: s.developer || "",
+            dilution: s.dilution || "",
+            temperature: s.temperature || "",
+            time: s.time || ""
+        });
+        setVisibility(toVisibility(s));
+    };
 
     useEffect(() => {
         setIsMac(System.IsMac());
 
         // Load initial settings
-        AppAPI.GetSettings().then((s: Settings) => {
-            setFullSettings(s);
-            setWatchFolder(s.watchFolder || "");
-            setExportFolder(s.exportFolder || "");
-        }).catch((err: any) => console.error("Failed to load settings:", err));
+        AppAPI.GetSettings().then(loadSettings).catch((err: any) => console.error("Failed to load settings:", err));
 
         // Listen for settings_saved from main window
         const unsub = Events.On("settings_saved", () => {
-            AppAPI.GetSettings().then((s: Settings) => {
-                setFullSettings(s);
-                setWatchFolder(s.watchFolder || "");
-                setExportFolder(s.exportFolder || "");
-            }).catch((err: any) => console.error("Failed to reload settings:", err));
+            AppAPI.GetSettings().then(loadSettings).catch((err: any) => console.error("Failed to reload settings:", err));
         });
 
         return () => {
@@ -34,16 +121,33 @@ function SettingsWindow() {
         };
     }, []);
 
-    const handleSave = async (newWatch: string, newExport: string) => {
-        if (!fullSettings) return;
-
+    const handleSave = async () => {
         const s = new Settings();
-        // Copy existing settings
-        Object.assign(s, fullSettings);
+        
+        s.watchFolder = watchFolder;
+        s.exportFolder = exportFolder;
+        s.aspectRatioPreset = aspectRatioPreset;
+        s.customRatioW = customRatioW;
+        s.customRatioH = customRatioH;
+        s.orientation = orientation;
+        s.alignment = alignment;
+        s.showPipeSeparator = showPipeSeparator;
+        
+        s.profile = profile;
+        s.overrideExif = overrideExif;
+        s.camera = exif.camera;
+        s.lens = exif.lens;
+        s.focalLength = exif.focalLength;
+        s.aperture = exif.aperture;
+        s.shutterSpeed = exif.shutterSpeed;
+        s.iso = exif.iso;
+        s.film = exif.film;
+        s.developer = exif.developer;
+        s.dilution = exif.dilution;
+        s.temperature = exif.temperature;
+        s.time = exif.time;
 
-        // Update folders
-        s.watchFolder = newWatch;
-        s.exportFolder = newExport;
+        applyVisibility(s, visibility);
 
         try {
             const errStr = await AppAPI.SaveSettings(s);
@@ -53,61 +157,123 @@ function SettingsWindow() {
                 return;
             }
 
-            // Update local state
-            setWatchFolder(newWatch);
-            setExportFolder(newExport);
-            setFullSettings(s);
-
             // Notify other windows
             Events.Emit("settings_saved");
+            
+            showToast("Settings saved successfully.");
         } catch (e: any) {
             console.error("Error saving settings", e);
         }
     };
 
     return (
-        <div className={`app-container ${isMac ? 'mac-os' : ''}`} style={{ height: '100vh', overflow: 'hidden' }}>
-            <header className="top-bar">
+        <div className={`app-container ${isMac ? 'mac-os' : ''}`} style={{ height: '100vh', display: 'flex', flexDirection: 'column', backgroundColor: 'var(--bg-main)' }}>
+            <header className="top-bar" style={{ flexShrink: 0, '--wails-draggable': 'drag' } as any}>
                 <h1>Preferences</h1>
             </header>
-            <main className="workspace" style={{ padding: '2rem', display: 'block', height: '100%' }}>
-                <div className="input-group" style={{ marginBottom: '1.5rem' }}>
-                    <label>Watch Folder (Auto-process)</label>
-                    <div style={{ display: 'flex', gap: '8px' }}>
-                        <input
-                            type="text"
-                            value={watchFolder}
-                            readOnly
-                            placeholder="/path/to/watch/folder"
-                            style={{ flex: 1 }}
-                        />
-                        <button onClick={async () => {
-                            const path = await AppAPI.SelectWatchFolder();
-                            if (path) handleSave(path, exportFolder);
-                        }} className="btn btn-secondary">Select</button>
-                        <button onClick={() => handleSave("", exportFolder)} className="btn btn-secondary" title="Clear Folder">✕</button>
+
+            <div className="workspace" style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
+                <aside className="sidebar" style={{ width: '220px', borderRight: '1px solid var(--border-color)', flexShrink: 0 }}>
+                    <div className="sidebar-section" style={{ borderBottom: 'none' }}>
+                        <button className={`nav-btn ${activeTab === 'general' ? 'active' : ''}`} onClick={() => setActiveTab('general')}>
+                            General
+                        </button>
+                        <button className={`nav-btn ${activeTab === 'frame' ? 'active' : ''}`} onClick={() => setActiveTab('frame')}>
+                            Frame Defaults
+                        </button>
+                        <button className={`nav-btn ${activeTab === 'metadata' ? 'active' : ''}`} onClick={() => setActiveTab('metadata')}>
+                            Metadata Defaults
+                        </button>
                     </div>
-                    <small>Images dropped here will be processed automatically.</small>
+                </aside>
+
+                <main style={{ flex: 1, padding: '2rem', overflowY: 'auto', backgroundColor: 'var(--bg-main)' }}>
+                    {activeTab === 'general' && (
+                        <div>
+                            <h2 style={{ marginBottom: '1.5rem', color: 'var(--text-primary)', textAlign: 'left' }}>General Settings</h2>
+                            <div className="input-group" style={{ marginBottom: '2rem' }}>
+                                <label>Watch Folder (Auto-process)</label>
+                                <div style={{ display: 'flex', gap: '8px' }}>
+                                    <input
+                                        type="text"
+                                        value={watchFolder}
+                                        readOnly
+                                        placeholder="/path/to/watch/folder"
+                                        style={{ flex: 1 }}
+                                    />
+                                    <button onClick={async () => {
+                                        const path = await AppAPI.SelectWatchFolder();
+                                        if (path) setWatchFolder(path);
+                                    }} className="btn btn-secondary">Select</button>
+                                    <button onClick={() => setWatchFolder("")} className="btn btn-secondary" title="Clear Folder">✕</button>
+                                </div>
+                                <small style={{ display: 'block', marginTop: '0.5rem', color: 'var(--text-secondary)', textAlign: 'left' }}>Images dropped here will be processed automatically.</small>
+                            </div>
+                            <div className="input-group">
+                                <label>Export Folder (Auto-save)</label>
+                                <div style={{ display: 'flex', gap: '8px' }}>
+                                    <input
+                                        type="text"
+                                        value={exportFolder}
+                                        readOnly
+                                        placeholder="/path/to/export/folder"
+                                        style={{ flex: 1 }}
+                                    />
+                                    <button onClick={async () => {
+                                        const path = await AppAPI.SelectExportFolder();
+                                        if (path) setExportFolder(path);
+                                    }} className="btn btn-secondary">Select</button>
+                                    <button onClick={() => setExportFolder("")} className="btn btn-secondary" title="Clear Folder">✕</button>
+                                </div>
+                                <small style={{ display: 'block', marginTop: '0.5rem', color: 'var(--text-secondary)', textAlign: 'left' }}>Auto-processed images will be saved here.</small>
+                            </div>
+                        </div>
+                    )}
+                    {activeTab === 'frame' && (
+                        <div>
+                            <h2 style={{ marginBottom: '1.5rem', color: 'var(--text-primary)', textAlign: 'left' }}>Frame Defaults</h2>
+                            <FrameSettingsPanel
+                                aspectRatioPreset={aspectRatioPreset} setAspectRatioPreset={setAspectRatioPreset}
+                                customRatioW={customRatioW} setCustomRatioW={setCustomRatioW}
+                                customRatioH={customRatioH} setCustomRatioH={setCustomRatioH}
+                                orientation={orientation} setOrientation={setOrientation}
+                                alignment={alignment} setAlignment={setAlignment}
+                                showPipeSeparator={showPipeSeparator} setShowPipeSeparator={setShowPipeSeparator}
+                            />
+                        </div>
+                    )}
+                    {activeTab === 'metadata' && (
+                        <div>
+                            <h2 style={{ marginBottom: '1.5rem', color: 'var(--text-primary)', textAlign: 'left' }}>Metadata Defaults</h2>
+                            <MetadataSettingsPanel
+                                profile={profile} setProfile={setProfile}
+                                exif={exif} setExif={setExif}
+                                visibility={visibility} setVisibility={setVisibility}
+                                isDefaultMode={true}
+                                overrideExif={overrideExif}
+                                setOverrideExif={setOverrideExif}
+                            />
+                        </div>
+                    )}
+                </main>
+            </div>
+
+            {toastMessage && (
+                <div className="toast-container" aria-live="polite" aria-atomic="true" role="status">
+                    <div className="toast success" style={{ animationDuration: `${TOAST_DURATION_MS}ms` }}>{toastMessage}</div>
                 </div>
-                <div className="input-group">
-                    <label>Export Folder (Auto-save)</label>
-                    <div style={{ display: 'flex', gap: '8px' }}>
-                        <input
-                            type="text"
-                            value={exportFolder}
-                            readOnly
-                            placeholder="/path/to/export/folder"
-                            style={{ flex: 1 }}
-                        />
-                        <button onClick={async () => {
-                            const path = await AppAPI.SelectExportFolder();
-                            if (path) handleSave(watchFolder, path);
-                        }} className="btn btn-secondary">Select</button>
-                        <button onClick={() => handleSave(watchFolder, "")} className="btn btn-secondary" title="Clear Folder">✕</button>
-                    </div>
-                    <small>Auto-processed images will be saved here.</small>
-                </div>
-            </main>
+            )}
+
+            <footer style={{ 
+                padding: '1rem 2rem', 
+                borderTop: '1px solid var(--border-color)', 
+                display: 'flex', 
+                justifyContent: 'flex-end', 
+                backgroundColor: 'var(--bg-panel)',
+                flexShrink: 0
+            }}>
+                <button className="btn btn-primary" onClick={handleSave}>Save Settings</button>
+            </footer>
         </div>
     );
 }

--- a/frontend/src/components/FrameSettingsPanel.tsx
+++ b/frontend/src/components/FrameSettingsPanel.tsx
@@ -1,0 +1,135 @@
+export interface FrameSettingsPanelProps {
+    aspectRatioPreset: string;
+    setAspectRatioPreset: (val: string) => void;
+    customRatioW: number;
+    setCustomRatioW: (val: number) => void;
+    customRatioH: number;
+    setCustomRatioH: (val: number) => void;
+    orientation: "landscape" | "portrait";
+    setOrientation: (val: "landscape" | "portrait") => void;
+    alignment: "top" | "center";
+    setAlignment: (val: "top" | "center") => void;
+    showPipeSeparator: boolean;
+    setShowPipeSeparator: (val: boolean) => void;
+}
+
+export const FrameSettingsPanel = ({
+    aspectRatioPreset, setAspectRatioPreset,
+    customRatioW, setCustomRatioW,
+    customRatioH, setCustomRatioH,
+    orientation, setOrientation,
+    alignment, setAlignment,
+    showPipeSeparator, setShowPipeSeparator
+}: FrameSettingsPanelProps) => (
+    <div className="sidebar-section frame-settings-section">
+        <h3>Frame Settings</h3>
+        <div className="input-group">
+            <label htmlFor="aspect-ratio-preset">Aspect Ratio</label>
+            <select
+                id="aspect-ratio-preset"
+                value={aspectRatioPreset}
+                onChange={(e) => setAspectRatioPreset(e.target.value)}
+            >
+                <option value="4300:3618">Default (4300:3618)</option>
+                <option value="1:1">Square (1:1)</option>
+                <option value="3:2">3:2</option>
+                <option value="4:3">4:3</option>
+                <option value="16:9">16:9</option>
+                <option value="custom">Custom</option>
+            </select>
+        </div>
+        {aspectRatioPreset === "custom" && (
+            <div className="input-row">
+                <div className="input-group">
+                    <label htmlFor="custom-ratio-w">Width</label>
+                    <input
+                        id="custom-ratio-w"
+                        type="number"
+                        value={customRatioW || ''}
+                        onChange={e => setCustomRatioW(Number(e.target.value) || 0)}
+                        min="1"
+                    />
+                </div>
+                <div className="input-group">
+                    <label htmlFor="custom-ratio-h">Height</label>
+                    <input
+                        id="custom-ratio-h"
+                        type="number"
+                        value={customRatioH || ''}
+                        onChange={e => setCustomRatioH(Number(e.target.value) || 0)}
+                        min="1"
+                    />
+                </div>
+            </div>
+        )}
+        <div className="input-group">
+            <label>Orientation</label>
+            <div className={`segmented-control ${aspectRatioPreset === '1:1' ? 'disabled' : ''}`}>
+                <button
+                    type="button"
+                    className={`segment ${orientation === 'landscape' ? 'active' : ''}`}
+                    onClick={() => setOrientation('landscape')}
+                    disabled={aspectRatioPreset === '1:1'}
+                    aria-pressed={orientation === 'landscape'}
+                >
+                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="3" y="5" width="18" height="14" rx="2" ry="2"></rect></svg>
+                    Landscape
+                </button>
+                <button
+                    type="button"
+                    className={`segment ${orientation === 'portrait' ? 'active' : ''}`}
+                    onClick={() => setOrientation('portrait')}
+                    disabled={aspectRatioPreset === '1:1'}
+                    aria-pressed={orientation === 'portrait'}
+                >
+                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="5" y="3" width="14" height="18" rx="2" ry="2"></rect></svg>
+                    Portrait
+                </button>
+            </div>
+        </div>
+        <div className="input-group">
+            <label>Vertical Alignment</label>
+            <div className="segmented-control">
+                <button
+                    type="button"
+                    className={`segment ${alignment === 'top' ? 'active' : ''}`}
+                    onClick={() => setAlignment('top')}
+                    aria-pressed={alignment === 'top'}
+                >
+                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="4" y1="4" x2="20" y2="4"></line><rect x="8" y="8" width="8" height="8" rx="1" ry="1"></rect></svg>
+                    Top
+                </button>
+                <button
+                    type="button"
+                    className={`segment ${alignment === 'center' ? 'active' : ''}`}
+                    onClick={() => setAlignment('center')}
+                    aria-pressed={alignment === 'center'}
+                >
+                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="4" y1="12" x2="20" y2="12"></line><rect x="8" y="8" width="8" height="8" rx="1" ry="1"></rect></svg>
+                    Center
+                </button>
+            </div>
+        </div>
+        <div className="input-group">
+            <label>Separator Style</label>
+            <div className="segmented-control">
+                <button
+                    type="button"
+                    className={`segment ${showPipeSeparator ? 'active' : ''}`}
+                    onClick={() => setShowPipeSeparator(true)}
+                    aria-pressed={showPipeSeparator}
+                >
+                    Pipe (|)
+                </button>
+                <button
+                    type="button"
+                    className={`segment ${!showPipeSeparator ? 'active' : ''}`}
+                    onClick={() => setShowPipeSeparator(false)}
+                    aria-pressed={!showPipeSeparator}
+                >
+                    Space
+                </button>
+            </div>
+        </div>
+    </div>
+);

--- a/frontend/src/components/MetadataSettingsPanel.tsx
+++ b/frontend/src/components/MetadataSettingsPanel.tsx
@@ -1,0 +1,181 @@
+import { ExifData, MetadataVisibility } from '../types';
+import { ToggleInput } from './ToggleInput';
+
+export interface MetadataSettingsPanelProps {
+    profile: string;
+    setProfile: (val: string) => void;
+    exif: ExifData;
+    setExif: (updater: (prev: ExifData) => ExifData) => void;
+    visibility: MetadataVisibility;
+    setVisibility: (updater: (prev: MetadataVisibility) => MetadataVisibility) => void;
+    isDefaultMode?: boolean;
+    overrideExif?: boolean;
+    setOverrideExif?: (val: boolean) => void;
+}
+
+export const MetadataSettingsPanel = ({
+    profile, setProfile,
+    exif, setExif,
+    visibility, setVisibility,
+    isDefaultMode = false,
+    overrideExif = false,
+    setOverrideExif
+}: MetadataSettingsPanelProps) => {
+    const hideExifInputs = isDefaultMode && profile === 'digital' && !overrideExif;
+    
+    return (
+    <div className="sidebar-section metadata-settings-section">
+        <div className="metadata-settings-header">
+            <h3>Metadata Settings</h3>
+            <div className="segmented-control profile-selector">
+                <button
+                    type="button"
+                    className={`segment ${profile === 'digital' ? 'active' : ''}`}
+                    onClick={() => setProfile('digital')}
+                    aria-pressed={profile === 'digital'}
+                >
+                    Digital
+                </button>
+                <button
+                    type="button"
+                    className={`segment ${profile === 'film' ? 'active' : ''}`}
+                    onClick={() => setProfile('film')}
+                    aria-pressed={profile === 'film'}
+                >
+                    Film
+                </button>
+            </div>
+        </div>
+
+        {profile === 'digital' && isDefaultMode && setOverrideExif && (
+            <div style={{ marginBottom: '1.2rem', marginTop: '1rem', padding: '0.8rem', backgroundColor: 'var(--bg-panel)', borderRadius: '6px', border: '1px solid var(--border-color)' }}>
+                <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer', fontWeight: 'normal', margin: 0, color: 'var(--text-primary)', fontSize: '0.85rem' }}>
+                    <input 
+                        type="checkbox" 
+                        checked={overrideExif}
+                        onChange={(e) => setOverrideExif(e.target.checked)}
+                        style={{ margin: 0, width: 'auto', height: 'auto', cursor: 'pointer' }}
+                    />
+                    Prioritize Default Text over EXIF
+                </label>
+                <small style={{ display: 'block', marginTop: '0.5rem', marginLeft: '1.5rem', color: 'var(--text-secondary)', textAlign: 'left' }}>
+                    If enabled, the text entered here will override the actual EXIF data of processed photos.
+                </small>
+            </div>
+        )}
+
+        <ToggleInput
+            label="Camera"
+            id="camera-input"
+            value={exif.camera}
+            onChange={(e) => setExif(prev => ({ ...prev, camera: e.target.value }))}
+            visible={visibility.camera}
+            onToggleVisibility={() => setVisibility(prev => ({ ...prev, camera: !prev.camera }))}
+            hideInput={hideExifInputs}
+        />
+        <ToggleInput
+            label="Lens"
+            id="lens-input"
+            value={exif.lens}
+            onChange={(e) => setExif(prev => ({ ...prev, lens: e.target.value }))}
+            visible={visibility.lens}
+            onToggleVisibility={() => setVisibility(prev => ({ ...prev, lens: !prev.lens }))}
+            hideInput={hideExifInputs}
+        />
+
+        <div className="input-row">
+            <ToggleInput
+                label="Focal Length"
+                id="focalLength-input"
+                value={exif.focalLength}
+                onChange={(e) => setExif(prev => ({ ...prev, focalLength: e.target.value }))}
+                visible={visibility.focalLength}
+                onToggleVisibility={() => setVisibility(prev => ({ ...prev, focalLength: !prev.focalLength }))}
+                hideInput={hideExifInputs}
+            />
+            <ToggleInput
+                label="Aperture"
+                id="aperture-input"
+                value={exif.aperture}
+                onChange={(e) => setExif(prev => ({ ...prev, aperture: e.target.value }))}
+                visible={visibility.aperture}
+                onToggleVisibility={() => setVisibility(prev => ({ ...prev, aperture: !prev.aperture }))}
+                hideInput={hideExifInputs}
+            />
+        </div>
+
+        <div className="input-row">
+            <ToggleInput
+                label="Shutter Speed"
+                id="shutterSpeed-input"
+                value={exif.shutterSpeed}
+                onChange={(e) => setExif(prev => ({ ...prev, shutterSpeed: e.target.value }))}
+                visible={visibility.shutterSpeed}
+                onToggleVisibility={() => setVisibility(prev => ({ ...prev, shutterSpeed: !prev.shutterSpeed }))}
+                hideInput={hideExifInputs}
+            />
+            {profile === 'digital' ? (
+                <ToggleInput
+                    label="ISO"
+                    id="iso-input"
+                    value={exif.iso}
+                    onChange={(e) => setExif(prev => ({ ...prev, iso: e.target.value }))}
+                    visible={visibility.iso}
+                    onToggleVisibility={() => setVisibility(prev => ({ ...prev, iso: !prev.iso }))}
+                    hideInput={hideExifInputs}
+                />
+            ) : (
+                <ToggleInput
+                    label="Film"
+                    id="film-input"
+                    value={exif.film}
+                    onChange={(e) => setExif(prev => ({ ...prev, film: e.target.value }))}
+                    visible={visibility.film}
+                    onToggleVisibility={() => setVisibility(prev => ({ ...prev, film: !prev.film }))}
+                />
+            )}
+        </div>
+
+        {profile === 'film' && (
+            <>
+                <div className="input-row">
+                    <ToggleInput
+                        label="Developer"
+                        id="developer-input"
+                        value={exif.developer}
+                        onChange={(e) => setExif(prev => ({ ...prev, developer: e.target.value }))}
+                        visible={visibility.developer}
+                        onToggleVisibility={() => setVisibility(prev => ({ ...prev, developer: !prev.developer }))}
+                    />
+                    <ToggleInput
+                        label="Dilution"
+                        id="dilution-input"
+                        value={exif.dilution}
+                        onChange={(e) => setExif(prev => ({ ...prev, dilution: e.target.value }))}
+                        visible={visibility.dilution}
+                        onToggleVisibility={() => setVisibility(prev => ({ ...prev, dilution: !prev.dilution }))}
+                    />
+                </div>
+                <div className="input-row">
+                    <ToggleInput
+                        label="Temperature"
+                        id="temperature-input"
+                        value={exif.temperature}
+                        onChange={(e) => setExif(prev => ({ ...prev, temperature: e.target.value }))}
+                        visible={visibility.temperature}
+                        onToggleVisibility={() => setVisibility(prev => ({ ...prev, temperature: !prev.temperature }))}
+                    />
+                    <ToggleInput
+                        label="Time"
+                        id="time-input"
+                        value={exif.time}
+                        onChange={(e) => setExif(prev => ({ ...prev, time: e.target.value }))}
+                        visible={visibility.time}
+                        onToggleVisibility={() => setVisibility(prev => ({ ...prev, time: !prev.time }))}
+                    />
+                </div>
+            </>
+        )}
+    </div>
+    );
+};

--- a/frontend/src/components/ToggleInput.tsx
+++ b/frontend/src/components/ToggleInput.tsx
@@ -1,0 +1,46 @@
+import { ChangeEvent } from 'react';
+
+const EyeIcon = ({ visible }: { visible: boolean }) => (
+    visible ? (
+        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path><circle cx="12" cy="12" r="3"></circle></svg>
+    ) : (
+        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path><line x1="1" y1="1" x2="23" y2="23"></line></svg>
+    )
+);
+
+export interface ToggleInputProps {
+    label: string;
+    id: string;
+    value: string;
+    onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+    visible: boolean;
+    onToggleVisibility: () => void;
+    hideInput?: boolean;
+}
+
+export const ToggleInput = ({ label, id, value, onChange, visible, onToggleVisibility, hideInput }: ToggleInputProps) => (
+    <div className="input-group">
+        <div className="toggle-input-header">
+            <label htmlFor={id} className="toggle-input-label">{label}</label>
+            <button
+                type="button"
+                onClick={onToggleVisibility}
+                className={`toggle-visibility-btn ${visible ? 'visible' : ''}`}
+                title={visible ? `Hide ${label} from frame` : `Show ${label} on frame`}
+                aria-label={visible ? `Hide ${label} from frame` : `Show ${label} on frame`}
+                aria-pressed={visible}
+            >
+                <EyeIcon visible={visible} />
+            </button>
+        </div>
+        {!hideInput && (
+            <input
+                id={id}
+                type="text"
+                value={value}
+                onChange={onChange}
+                className={`toggle-input-field ${!visible ? 'hidden' : ''}`}
+            />
+        )}
+    </div>
+);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,48 @@
+export interface ExifData {
+    camera: string;
+    lens: string;
+    focalLength: string;
+    aperture: string;
+    shutterSpeed: string;
+    iso: string;
+    film: string;
+    developer: string;
+    dilution: string;
+    temperature: string;
+    time: string;
+}
+
+export interface MetadataVisibility {
+    camera: boolean;
+    lens: boolean;
+    focalLength: boolean;
+    aperture: boolean;
+    shutterSpeed: boolean;
+    iso: boolean;
+    film: boolean;
+    developer: boolean;
+    dilution: boolean;
+    temperature: boolean;
+    time: boolean;
+}
+
+export const VISIBILITY_KEYS = [
+    'camera', 'lens', 'focalLength', 'aperture', 'shutterSpeed', 'iso',
+    'film', 'developer', 'dilution', 'temperature', 'time',
+] as const;
+
+export const settingsKey = (k: typeof VISIBILITY_KEYS[number]) =>
+    k === 'iso' ? 'visibilityISO' : `visibility${k.charAt(0).toUpperCase()}${k.slice(1)}`;
+
+export function toVisibility(s: Record<string, unknown>): MetadataVisibility {
+    const result: Partial<MetadataVisibility> = {};
+    VISIBILITY_KEYS.forEach(k => {
+        const val = s[settingsKey(k)];
+        result[k] = typeof val === 'boolean' ? val : true;
+    });
+    return result as MetadataVisibility;
+}
+
+export function applyVisibility(s: Record<string, unknown>, v: MetadataVisibility): void {
+    VISIBILITY_KEYS.forEach(k => { s[settingsKey(k)] = v[k]; });
+}

--- a/settings.go
+++ b/settings.go
@@ -22,12 +22,19 @@ type Settings struct {
 	ShowPipeSeparator bool   `json:"showPipeSeparator"`
 
 	// New fields for Profiles and Film metadata
-	Profile     string `json:"profile"`
-	Film        string `json:"film"`
-	Developer   string `json:"developer"`
-	Dilution    string `json:"dilution"`
-	Temperature string `json:"temperature"`
-	Time        string `json:"time"`
+	Profile      string `json:"profile"`
+	Camera       string `json:"camera"`
+	Lens         string `json:"lens"`
+	FocalLength  string `json:"focalLength"`
+	Aperture     string `json:"aperture"`
+	ShutterSpeed string `json:"shutterSpeed"`
+	ISO          string `json:"iso"`
+	Film         string `json:"film"`
+	Developer    string `json:"developer"`
+	Dilution     string `json:"dilution"`
+	Temperature  string `json:"temperature"`
+	Time         string `json:"time"`
+	OverrideExif bool   `json:"overrideExif"`
 
 	// Visibility toggles
 	VisibilityCamera       bool `json:"visibilityCamera"`


### PR DESCRIPTION
- Extract UI components (FrameSettingsPanel, MetadataSettingsPanel, ToggleInput)
- Add "Save as Auto-Export Default" button to main view, removing automatic background saving
- Redesign Settings window with a tabbed sidebar and increase initial size to 800x600
- Add EXIF override capability for Digital profiles with `OverrideExif` toggle
- Improve settings type safety, fix CSS variable typos, and clean up inline styles
- Add toast notification for saving settings

resolved #31