### PR TITLE
fix: use query parameters for settings window routing to prevent whiteout

### DIFF
--- a/app.go
+++ b/app.go
@@ -663,7 +663,7 @@ func (a *App) OpenSettingsWindow() {
 			TitleBar: application.MacTitleBarHiddenInsetUnified,
 		},
 		BackgroundColour: application.NewRGB(27, 38, 54),
-		URL:              "/settings",
+		URL:              "/?page=settings",
 	})
 }
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -8,7 +8,8 @@ const container = document.getElementById('root')
 
 const root = createRoot(container!)
 
-if (window.location.pathname === '/settings') {
+const urlParams = new URLSearchParams(window.location.search);
+if (window.location.pathname === '/settings' || urlParams.get('page') === 'settings') {
     root.render(
         <React.StrictMode>
             <SettingsWindow />


### PR DESCRIPTION
fixed #100 