### PR TITLE
test: expand test coverage for Go backend and frontend

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"regexp"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// formatFocalLength
+// ---------------------------------------------------------------------------
+
+func TestFormatFocalLength(t *testing.T) {
+	tests := []struct {
+		name     string
+		num, den int64
+		want     string
+	}{
+		{"zero denominator", 50, 0, ""},
+		{"integer value", 50, 1, "50mm"},
+		{"fractional value", 350, 10, "35mm"},
+		{"large rational", 2400, 100, "24mm"},
+		{"decimal result", 185, 10, "18.5mm"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatFocalLength(tt.num, tt.den)
+			if got != tt.want {
+				t.Errorf("formatFocalLength(%d, %d) = %q, want %q", tt.num, tt.den, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// formatAperture
+// ---------------------------------------------------------------------------
+
+func TestFormatAperture(t *testing.T) {
+	tests := []struct {
+		name     string
+		num, den int64
+		want     string
+	}{
+		{"zero denominator", 28, 0, ""},
+		{"f/2.8", 28, 10, "f/2.8"},
+		{"f/1.4", 14, 10, "f/1.4"},
+		{"f/8.0", 8, 1, "f/8.0"},
+		{"f/5.6", 56, 10, "f/5.6"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatAperture(tt.num, tt.den)
+			if got != tt.want {
+				t.Errorf("formatAperture(%d, %d) = %q, want %q", tt.num, tt.den, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// formatShutterSpeed
+// ---------------------------------------------------------------------------
+
+func TestFormatShutterSpeed(t *testing.T) {
+	tests := []struct {
+		name     string
+		num, den int64
+		want     string
+	}{
+		{"zero numerator", 0, 250, ""},
+		{"zero denominator", 1, 0, ""},
+		{"both zero", 0, 0, ""},
+		{"integer seconds", 30, 1, "30s"},
+		{"1/250s", 1, 250, "1/250s"},
+		{"1/8000s", 1, 8000, "1/8000s"},
+		{"reducible fraction 10/2500", 10, 2500, "1/250s"},
+		{"non-unit numerator 2/5", 2, 5, "2/5s"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatShutterSpeed(tt.num, tt.den)
+			if got != tt.want {
+				t.Errorf("formatShutterSpeed(%d, %d) = %q, want %q", tt.num, tt.den, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// gcd
+// ---------------------------------------------------------------------------
+
+func TestGcd(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b int64
+		want int64
+	}{
+		{"basic", 12, 8, 4},
+		{"coprime", 7, 13, 1},
+		{"same", 5, 5, 5},
+		{"one is zero", 0, 7, 7},
+		{"both zero returns 1", 0, 0, 1},
+		{"negative a", -12, 8, 4},
+		{"negative b", 12, -8, 4},
+		{"both negative", -12, -8, 4},
+		{"large values", 1000000, 250, 250},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := gcd(tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("gcd(%d, %d) = %d, want %d", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseFraction
+// ---------------------------------------------------------------------------
+
+func TestParseFraction(t *testing.T) {
+	tests := []struct {
+		name            string
+		input           string
+		wantNum, wantDen int64
+	}{
+		{"simple fraction", "1/250", 1, 250},
+		{"large fraction", "10/32000", 10, 32000},
+		{"float value", "35.0", 350000, 10000},
+		{"float fractional", "2.8", 28000, 10000},
+		{"integer as float", "50", 500000, 10000},
+		{"invalid string", "abc", 0, 0},
+		{"empty string", "", 0, 0},
+		{"fraction with bad num", "abc/100", 0, 0},
+		{"fraction with bad den", "1/abc", 0, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotNum, gotDen := parseFraction(tt.input)
+			if gotNum != tt.wantNum || gotDen != tt.wantDen {
+				t.Errorf("parseFraction(%q) = (%d, %d), want (%d, %d)",
+					tt.input, gotNum, gotDen, tt.wantNum, tt.wantDen)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// extractXMPString
+// ---------------------------------------------------------------------------
+
+func TestExtractXMPString(t *testing.T) {
+	sampleXMP := []byte(`<x:xmpmeta xmlns:x="adobe:ns:meta/">
+		<rdf:Description tiff:Model="Canon EOS R5" aux:Lens="RF50mm F1.2 L USM"/>
+	</x:xmpmeta>`)
+
+	tests := []struct {
+		name string
+		data []byte
+		re   *regexp.Regexp
+		want string
+	}{
+		{"match model", sampleXMP, reXmpModel, "Canon EOS R5"},
+		{"match lens", sampleXMP, reXmpLens, "RF50mm F1.2 L USM"},
+		{"no match", sampleXMP, regexp.MustCompile(`nonexistent="([^"]+)"`), ""},
+		{"nil data", nil, reXmpModel, ""},
+		{"empty data", []byte{}, reXmpModel, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Fix: the function signature is extractXMPString(data, re)
+			got := extractXMPString(tt.data, tt.re)
+			if got != tt.want {
+				t.Errorf("extractXMPString() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractXMPStringWithLens(t *testing.T) {
+	xmpWithLens := []byte(`<x:xmpmeta>
+		<rdf:Description aux:Lens="RF85mm F1.2 L USM" exifEX:LensModel="RF85mm"/>
+	</x:xmpmeta>`)
+
+	got := extractXMPString(xmpWithLens, reXmpLens)
+	if got != "RF85mm F1.2 L USM" {
+		t.Errorf("extractXMPString(aux:Lens) = %q, want %q", got, "RF85mm F1.2 L USM")
+	}
+
+	got = extractXMPString(xmpWithLens, reXmpExifLens)
+	if got != "RF85mm" {
+		t.Errorf("extractXMPString(exifEX:LensModel) = %q, want %q", got, "RF85mm")
+	}
+}
+
+func TestExtractXMPStringISO(t *testing.T) {
+	xmpWithISO := []byte(`<x:xmpmeta>
+		<exif:ISOSpeedRatings>
+			<rdf:Seq><rdf:li>800</rdf:li></rdf:Seq>
+		</exif:ISOSpeedRatings>
+	</x:xmpmeta>`)
+
+	got := extractXMPString(xmpWithISO, reXmpISO)
+	if got != "800" {
+		t.Errorf("extractXMPString(ISO) = %q, want %q", got, "800")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ensureValidExtension
+// ---------------------------------------------------------------------------
+
+func TestEnsureValidExtension(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		isPng     bool
+		wantPath  string
+		wantError bool
+	}{
+		// No extension — append
+		{"no ext, jpeg", "/tmp/photo", false, "/tmp/photo.jpg", false},
+		{"no ext, png", "/tmp/photo", true, "/tmp/photo.png", false},
+
+		// Correct extension — pass through
+		{"correct .jpg", "/tmp/photo.jpg", false, "/tmp/photo.jpg", false},
+		{"correct .jpeg", "/tmp/photo.jpeg", false, "/tmp/photo.jpeg", false},
+		{"correct .png", "/tmp/photo.png", true, "/tmp/photo.png", false},
+
+		// Case insensitive
+		{"uppercase .JPG", "/tmp/photo.JPG", false, "/tmp/photo.JPG", false},
+		{"uppercase .PNG", "/tmp/photo.PNG", true, "/tmp/photo.PNG", false},
+
+		// Wrong extension — error
+		{"png with .jpg", "/tmp/photo.jpg", true, "", true},
+		{"jpeg with .png", "/tmp/photo.png", false, "", true},
+		{"jpeg with .bmp", "/tmp/photo.bmp", false, "", true},
+		{"png with .gif", "/tmp/photo.gif", true, "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ensureValidExtension(tt.path, tt.isPng)
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("ensureValidExtension(%q, %v) expected error, got nil", tt.path, tt.isPng)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("ensureValidExtension(%q, %v) unexpected error: %v", tt.path, tt.isPng, err)
+				return
+			}
+			if got != tt.wantPath {
+				t.Errorf("ensureValidExtension(%q, %v) = %q, want %q", tt.path, tt.isPng, got, tt.wantPath)
+			}
+		})
+	}
+}

--- a/app_test.go
+++ b/app_test.go
@@ -170,7 +170,6 @@ func TestExtractXMPString(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Fix: the function signature is extractXMPString(data, re)
 			got := extractXMPString(tt.data, tt.re)
 			if got != tt.want {
 				t.Errorf("extractXMPString() = %q, want %q", got, tt.want)

--- a/frontend/src/types.test.ts
+++ b/frontend/src/types.test.ts
@@ -8,6 +8,15 @@ import {
 } from './types';
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeVisibility(value: boolean, overrides: Partial<MetadataVisibility> = {}): MetadataVisibility {
+    const base = Object.fromEntries(VISIBILITY_KEYS.map((k) => [k, value])) as unknown as MetadataVisibility;
+    return { ...base, ...overrides };
+}
+
+// ---------------------------------------------------------------------------
 // settingsKey
 // ---------------------------------------------------------------------------
 
@@ -111,19 +120,13 @@ describe('toVisibility', () => {
 describe('applyVisibility', () => {
     it('writes visibility flags to settings object', () => {
         const settings: Record<string, unknown> = {};
-        const vis: MetadataVisibility = {
-            camera: true,
+        const vis = makeVisibility(true, {
             lens: false,
-            focalLength: true,
             aperture: false,
-            shutterSpeed: true,
             iso: false,
-            film: true,
             developer: false,
-            dilution: true,
             temperature: false,
-            time: true,
-        };
+        });
         applyVisibility(settings, vis);
 
         expect(settings['visibilityCamera']).toBe(true);
@@ -144,19 +147,7 @@ describe('applyVisibility', () => {
             visibilityCamera: false,
             visibilityLens: true,
         };
-        const vis: MetadataVisibility = {
-            camera: true,
-            lens: false,
-            focalLength: true,
-            aperture: true,
-            shutterSpeed: true,
-            iso: true,
-            film: true,
-            developer: true,
-            dilution: true,
-            temperature: true,
-            time: true,
-        };
+        const vis = makeVisibility(true, { lens: false });
         applyVisibility(settings, vis);
 
         expect(settings['visibilityCamera']).toBe(true);
@@ -170,19 +161,7 @@ describe('applyVisibility', () => {
             frameColor: '#ffffff',
             visibilityCamera: false,
         };
-        const vis: MetadataVisibility = {
-            camera: true,
-            lens: true,
-            focalLength: true,
-            aperture: true,
-            shutterSpeed: true,
-            iso: true,
-            film: true,
-            developer: true,
-            dilution: true,
-            temperature: true,
-            time: true,
-        };
+        const vis = makeVisibility(true);
         applyVisibility(settings, vis);
 
         // Visibility keys are updated
@@ -200,19 +179,13 @@ describe('applyVisibility', () => {
 
 describe('roundtrip applyVisibility -> toVisibility', () => {
     it('preserves all values through a round trip', () => {
-        const original: MetadataVisibility = {
-            camera: true,
+        const original = makeVisibility(true, {
             lens: false,
-            focalLength: true,
             aperture: false,
-            shutterSpeed: true,
             iso: false,
-            film: true,
             developer: false,
-            dilution: true,
             temperature: false,
-            time: true,
-        };
+        });
 
         const settings: Record<string, unknown> = {};
         applyVisibility(settings, original);
@@ -224,19 +197,7 @@ describe('roundtrip applyVisibility -> toVisibility', () => {
     });
 
     it('works with all-true values', () => {
-        const allTrue: MetadataVisibility = {
-            camera: true,
-            lens: true,
-            focalLength: true,
-            aperture: true,
-            shutterSpeed: true,
-            iso: true,
-            film: true,
-            developer: true,
-            dilution: true,
-            temperature: true,
-            time: true,
-        };
+        const allTrue = makeVisibility(true);
 
         const settings: Record<string, unknown> = {};
         applyVisibility(settings, allTrue);
@@ -248,19 +209,7 @@ describe('roundtrip applyVisibility -> toVisibility', () => {
     });
 
     it('works with all-false values', () => {
-        const allFalse: MetadataVisibility = {
-            camera: false,
-            lens: false,
-            focalLength: false,
-            aperture: false,
-            shutterSpeed: false,
-            iso: false,
-            film: false,
-            developer: false,
-            dilution: false,
-            temperature: false,
-            time: false,
-        };
+        const allFalse = makeVisibility(false);
 
         const settings: Record<string, unknown> = {};
         applyVisibility(settings, allFalse);

--- a/frontend/src/types.test.ts
+++ b/frontend/src/types.test.ts
@@ -29,13 +29,15 @@ describe('settingsKey', () => {
         expect(settingsKey('time')).toBe('visibilityTime');
     });
 
-    it('covers all VISIBILITY_KEYS', () => {
-        // Ensure every key in VISIBILITY_KEYS produces a non-empty string
-        for (const k of VISIBILITY_KEYS) {
-            const result = settingsKey(k);
+    it('covers all VISIBILITY_KEYS without collisions', () => {
+        const mapped = VISIBILITY_KEYS.map(settingsKey);
+        // Ensure every key produces a non-empty visibility-prefixed string
+        for (const result of mapped) {
             expect(result).toBeTruthy();
             expect(result.startsWith('visibility')).toBe(true);
         }
+        // Ensure no two keys collide on the same settings key
+        expect(new Set(mapped).size).toBe(VISIBILITY_KEYS.length);
     });
 });
 

--- a/frontend/src/types.test.ts
+++ b/frontend/src/types.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from 'vitest';
+import {
+    settingsKey,
+    toVisibility,
+    applyVisibility,
+    VISIBILITY_KEYS,
+    type MetadataVisibility,
+} from './types';
+
+// ---------------------------------------------------------------------------
+// settingsKey
+// ---------------------------------------------------------------------------
+
+describe('settingsKey', () => {
+    it('maps "iso" to "visibilityISO" (special case)', () => {
+        expect(settingsKey('iso')).toBe('visibilityISO');
+    });
+
+    it('maps standard keys with uppercase first letter', () => {
+        expect(settingsKey('camera')).toBe('visibilityCamera');
+        expect(settingsKey('lens')).toBe('visibilityLens');
+        expect(settingsKey('focalLength')).toBe('visibilityFocalLength');
+        expect(settingsKey('aperture')).toBe('visibilityAperture');
+        expect(settingsKey('shutterSpeed')).toBe('visibilityShutterSpeed');
+        expect(settingsKey('film')).toBe('visibilityFilm');
+        expect(settingsKey('developer')).toBe('visibilityDeveloper');
+        expect(settingsKey('dilution')).toBe('visibilityDilution');
+        expect(settingsKey('temperature')).toBe('visibilityTemperature');
+        expect(settingsKey('time')).toBe('visibilityTime');
+    });
+
+    it('covers all VISIBILITY_KEYS', () => {
+        // Ensure every key in VISIBILITY_KEYS produces a non-empty string
+        for (const k of VISIBILITY_KEYS) {
+            const result = settingsKey(k);
+            expect(result).toBeTruthy();
+            expect(result.startsWith('visibility')).toBe(true);
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// toVisibility
+// ---------------------------------------------------------------------------
+
+describe('toVisibility', () => {
+    it('returns all true when settings have all visibility flags set', () => {
+        const settings: Record<string, unknown> = {};
+        for (const k of VISIBILITY_KEYS) {
+            settings[settingsKey(k)] = true;
+        }
+        const vis = toVisibility(settings);
+        for (const k of VISIBILITY_KEYS) {
+            expect(vis[k]).toBe(true);
+        }
+    });
+
+    it('returns false for explicitly false flags', () => {
+        const settings: Record<string, unknown> = {};
+        for (const k of VISIBILITY_KEYS) {
+            settings[settingsKey(k)] = false;
+        }
+        const vis = toVisibility(settings);
+        for (const k of VISIBILITY_KEYS) {
+            expect(vis[k]).toBe(false);
+        }
+    });
+
+    it('defaults missing values to true', () => {
+        const vis = toVisibility({});
+        for (const k of VISIBILITY_KEYS) {
+            expect(vis[k]).toBe(true);
+        }
+    });
+
+    it('treats non-boolean values as true (default)', () => {
+        const settings: Record<string, unknown> = {
+            visibilityCamera: 'yes',
+            visibilityLens: 1,
+            visibilityISO: null,
+        };
+        const vis = toVisibility(settings);
+        expect(vis.camera).toBe(true);
+        expect(vis.lens).toBe(true);
+        expect(vis.iso).toBe(true);
+    });
+
+    it('handles mixed true/false flags', () => {
+        const settings: Record<string, unknown> = {
+            visibilityCamera: true,
+            visibilityLens: false,
+            visibilityFocalLength: true,
+            visibilityAperture: false,
+        };
+        const vis = toVisibility(settings);
+        expect(vis.camera).toBe(true);
+        expect(vis.lens).toBe(false);
+        expect(vis.focalLength).toBe(true);
+        expect(vis.aperture).toBe(false);
+        // Missing keys default to true
+        expect(vis.shutterSpeed).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// applyVisibility
+// ---------------------------------------------------------------------------
+
+describe('applyVisibility', () => {
+    it('writes visibility flags to settings object', () => {
+        const settings: Record<string, unknown> = {};
+        const vis: MetadataVisibility = {
+            camera: true,
+            lens: false,
+            focalLength: true,
+            aperture: false,
+            shutterSpeed: true,
+            iso: false,
+            film: true,
+            developer: false,
+            dilution: true,
+            temperature: false,
+            time: true,
+        };
+        applyVisibility(settings, vis);
+
+        expect(settings['visibilityCamera']).toBe(true);
+        expect(settings['visibilityLens']).toBe(false);
+        expect(settings['visibilityFocalLength']).toBe(true);
+        expect(settings['visibilityAperture']).toBe(false);
+        expect(settings['visibilityShutterSpeed']).toBe(true);
+        expect(settings['visibilityISO']).toBe(false);
+        expect(settings['visibilityFilm']).toBe(true);
+        expect(settings['visibilityDeveloper']).toBe(false);
+        expect(settings['visibilityDilution']).toBe(true);
+        expect(settings['visibilityTemperature']).toBe(false);
+        expect(settings['visibilityTime']).toBe(true);
+    });
+
+    it('overwrites existing values in the settings object', () => {
+        const settings: Record<string, unknown> = {
+            visibilityCamera: false,
+            visibilityLens: true,
+        };
+        const vis: MetadataVisibility = {
+            camera: true,
+            lens: false,
+            focalLength: true,
+            aperture: true,
+            shutterSpeed: true,
+            iso: true,
+            film: true,
+            developer: true,
+            dilution: true,
+            temperature: true,
+            time: true,
+        };
+        applyVisibility(settings, vis);
+
+        expect(settings['visibilityCamera']).toBe(true);
+        expect(settings['visibilityLens']).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// roundtrip: applyVisibility -> toVisibility
+// ---------------------------------------------------------------------------
+
+describe('roundtrip applyVisibility -> toVisibility', () => {
+    it('preserves all values through a round trip', () => {
+        const original: MetadataVisibility = {
+            camera: true,
+            lens: false,
+            focalLength: true,
+            aperture: false,
+            shutterSpeed: true,
+            iso: false,
+            film: true,
+            developer: false,
+            dilution: true,
+            temperature: false,
+            time: true,
+        };
+
+        const settings: Record<string, unknown> = {};
+        applyVisibility(settings, original);
+        const restored = toVisibility(settings);
+
+        for (const k of VISIBILITY_KEYS) {
+            expect(restored[k]).toBe(original[k]);
+        }
+    });
+
+    it('works with all-true values', () => {
+        const allTrue: MetadataVisibility = {
+            camera: true,
+            lens: true,
+            focalLength: true,
+            aperture: true,
+            shutterSpeed: true,
+            iso: true,
+            film: true,
+            developer: true,
+            dilution: true,
+            temperature: true,
+            time: true,
+        };
+
+        const settings: Record<string, unknown> = {};
+        applyVisibility(settings, allTrue);
+        const restored = toVisibility(settings);
+
+        for (const k of VISIBILITY_KEYS) {
+            expect(restored[k]).toBe(true);
+        }
+    });
+
+    it('works with all-false values', () => {
+        const allFalse: MetadataVisibility = {
+            camera: false,
+            lens: false,
+            focalLength: false,
+            aperture: false,
+            shutterSpeed: false,
+            iso: false,
+            film: false,
+            developer: false,
+            dilution: false,
+            temperature: false,
+            time: false,
+        };
+
+        const settings: Record<string, unknown> = {};
+        applyVisibility(settings, allFalse);
+        const restored = toVisibility(settings);
+
+        for (const k of VISIBILITY_KEYS) {
+            expect(restored[k]).toBe(false);
+        }
+    });
+});

--- a/frontend/src/types.test.ts
+++ b/frontend/src/types.test.ts
@@ -160,6 +160,36 @@ describe('applyVisibility', () => {
         expect(settings['visibilityCamera']).toBe(true);
         expect(settings['visibilityLens']).toBe(false);
     });
+
+    it('preserves unrelated keys in the settings object', () => {
+        const settings: Record<string, unknown> = {
+            watchFolder: '/photos',
+            exportFolder: '/export',
+            frameColor: '#ffffff',
+            visibilityCamera: false,
+        };
+        const vis: MetadataVisibility = {
+            camera: true,
+            lens: true,
+            focalLength: true,
+            aperture: true,
+            shutterSpeed: true,
+            iso: true,
+            film: true,
+            developer: true,
+            dilution: true,
+            temperature: true,
+            time: true,
+        };
+        applyVisibility(settings, vis);
+
+        // Visibility keys are updated
+        expect(settings['visibilityCamera']).toBe(true);
+        // Unrelated keys are preserved
+        expect(settings['watchFolder']).toBe('/photos');
+        expect(settings['exportFolder']).toBe('/export');
+        expect(settings['frameColor']).toBe('#ffffff');
+    });
 });
 
 // ---------------------------------------------------------------------------

--- a/handler_test.go
+++ b/handler_test.go
@@ -50,8 +50,12 @@ func TestRegisterImageToken_Basic(t *testing.T) {
 func TestRegisterImageToken_LRUEviction(t *testing.T) {
 	h := newTestHandler()
 
-	// Fill up to the max.
-	for i := 0; i < maxImageTokens; i++ {
+	// Register the first path and record its token.
+	firstPath := filepath.Join("/tmp", "first.jpg")
+	firstToken := h.registerImageToken(firstPath)
+
+	// Fill up to the max (first entry is already registered, so start at 1).
+	for i := 1; i < maxImageTokens; i++ {
 		h.registerImageToken(filepath.Join("/tmp", "img"+string(rune('A'+i%26))+string(rune('0'+i/26))+".jpg"))
 	}
 
@@ -59,10 +63,16 @@ func TestRegisterImageToken_LRUEviction(t *testing.T) {
 		t.Fatalf("expected %d tokens, got %d", maxImageTokens, len(h.imageTokens))
 	}
 
-	// Register one more — should evict the oldest.
+	// Register one more — should evict the oldest (firstPath).
 	h.registerImageToken("/tmp/overflow.jpg")
 	if len(h.imageTokens) != maxImageTokens {
 		t.Fatalf("after overflow expected %d tokens, got %d", maxImageTokens, len(h.imageTokens))
+	}
+
+	// The evicted path should now yield a fresh token, not the original.
+	newToken := h.registerImageToken(firstPath)
+	if newToken == firstToken {
+		t.Error("expected oldest entry to be evicted and re-registered with a new token")
 	}
 }
 
@@ -70,17 +80,22 @@ func TestRegisterImageToken_LRUEviction(t *testing.T) {
 // prepareSave / handleSave round-trip
 // ---------------------------------------------------------------------------
 
+// encodeTestJPEGBytes returns a small valid JPEG as a byte slice.
+func encodeTestJPEGBytes(t *testing.T) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	img.Set(0, 0, color.RGBA{255, 0, 0, 255})
+	if err := jpeg.Encode(&buf, img, nil); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
 // createTestJPEG writes a small valid JPEG to the given path.
 func createTestJPEG(t *testing.T, path string) {
 	t.Helper()
-	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
-	img.Set(0, 0, color.RGBA{255, 0, 0, 255})
-	f, err := os.Create(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer f.Close()
-	if err := jpeg.Encode(f, img, nil); err != nil {
+	if err := os.WriteFile(path, encodeTestJPEGBytes(t), 0644); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -93,15 +108,7 @@ func TestHandleSave_Success(t *testing.T) {
 
 	token := h.prepareSave(savePath, "image/jpeg")
 
-	// Create a valid JPEG body.
-	var body bytes.Buffer
-	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
-	img.Set(0, 0, color.RGBA{255, 0, 0, 255})
-	if err := jpeg.Encode(&body, img, nil); err != nil {
-		t.Fatal(err)
-	}
-
-	req := httptest.NewRequest(http.MethodPost, "/api/save?token="+token, &body)
+	req := httptest.NewRequest(http.MethodPost, "/api/save?token="+token, bytes.NewReader(encodeTestJPEGBytes(t)))
 	req.Header.Set("Content-Type", "image/jpeg")
 	w := httptest.NewRecorder()
 
@@ -154,11 +161,9 @@ func TestHandleSave_ExpiredToken(t *testing.T) {
 	}
 	h.saveMu.Unlock()
 
-	var body bytes.Buffer
-	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
-	jpeg.Encode(&body, img, nil)
+	jpegBody := encodeTestJPEGBytes(t)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/save?token="+token, &body)
+	req := httptest.NewRequest(http.MethodPost, "/api/save?token="+token, bytes.NewReader(jpegBody))
 	req.Header.Set("Content-Type", "image/jpeg")
 	w := httptest.NewRecorder()
 	h.handleSave(w, req)
@@ -405,10 +410,7 @@ func TestHandleSave_TokenConsumedOnce(t *testing.T) {
 	token := h.prepareSave(savePath, "image/jpeg")
 
 	makeBody := func() io.Reader {
-		var buf bytes.Buffer
-		img := image.NewRGBA(image.Rect(0, 0, 2, 2))
-		jpeg.Encode(&buf, img, nil)
-		return &buf
+		return bytes.NewReader(encodeTestJPEGBytes(t))
 	}
 
 	// First request succeeds.

--- a/handler_test.go
+++ b/handler_test.go
@@ -1,0 +1,431 @@
+package main
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"image/png"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// newTestHandler returns an ImageHandler wired to a dummy App (no Wails deps).
+func newTestHandler() *ImageHandler {
+	app := &App{}
+	h := NewImageHandler(app)
+	app.handler = h
+	return h
+}
+
+// ---------------------------------------------------------------------------
+// registerImageToken
+// ---------------------------------------------------------------------------
+
+func TestRegisterImageToken_Basic(t *testing.T) {
+	h := newTestHandler()
+	token := h.registerImageToken("/tmp/photo.jpg")
+	if token == "" {
+		t.Fatal("expected non-empty token")
+	}
+
+	// Same path should return the same token.
+	token2 := h.registerImageToken("/tmp/photo.jpg")
+	if token2 != token {
+		t.Errorf("same path should reuse token: got %q, want %q", token2, token)
+	}
+
+	// Different path should return a different token.
+	token3 := h.registerImageToken("/tmp/other.jpg")
+	if token3 == token {
+		t.Error("different path should produce a different token")
+	}
+}
+
+func TestRegisterImageToken_LRUEviction(t *testing.T) {
+	h := newTestHandler()
+
+	// Fill up to the max.
+	for i := 0; i < maxImageTokens; i++ {
+		h.registerImageToken(filepath.Join("/tmp", "img"+string(rune('A'+i%26))+string(rune('0'+i/26))+".jpg"))
+	}
+
+	if len(h.imageTokens) != maxImageTokens {
+		t.Fatalf("expected %d tokens, got %d", maxImageTokens, len(h.imageTokens))
+	}
+
+	// Register one more — should evict the oldest.
+	h.registerImageToken("/tmp/overflow.jpg")
+	if len(h.imageTokens) != maxImageTokens {
+		t.Fatalf("after overflow expected %d tokens, got %d", maxImageTokens, len(h.imageTokens))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// prepareSave / handleSave round-trip
+// ---------------------------------------------------------------------------
+
+// createTestJPEG writes a small valid JPEG to the given path.
+func createTestJPEG(t *testing.T, path string) {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	img.Set(0, 0, color.RGBA{255, 0, 0, 255})
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if err := jpeg.Encode(f, img, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestHandleSave_Success(t *testing.T) {
+	h := newTestHandler()
+
+	dir := t.TempDir()
+	savePath := filepath.Join(dir, "output.jpg")
+
+	token := h.prepareSave(savePath, "image/jpeg")
+
+	// Create a valid JPEG body.
+	var body bytes.Buffer
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	img.Set(0, 0, color.RGBA{255, 0, 0, 255})
+	if err := jpeg.Encode(&body, img, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/save?token="+token, &body)
+	req.Header.Set("Content-Type", "image/jpeg")
+	w := httptest.NewRecorder()
+
+	h.handleSave(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Verify the file was written.
+	if _, err := os.Stat(savePath); err != nil {
+		t.Errorf("saved file should exist: %v", err)
+	}
+}
+
+func TestHandleSave_MissingToken(t *testing.T) {
+	h := newTestHandler()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/save", nil)
+	w := httptest.NewRecorder()
+	h.handleSave(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleSave_InvalidToken(t *testing.T) {
+	h := newTestHandler()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/save?token=bogus", nil)
+	w := httptest.NewRecorder()
+	h.handleSave(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleSave_ExpiredToken(t *testing.T) {
+	h := newTestHandler()
+
+	dir := t.TempDir()
+	token := h.prepareSave(filepath.Join(dir, "out.jpg"), "image/jpeg")
+
+	// Manually expire the session.
+	h.saveMu.Lock()
+	if s, ok := h.saveSessions[token]; ok {
+		s.expiresAt = time.Now().Add(-1 * time.Second)
+	}
+	h.saveMu.Unlock()
+
+	var body bytes.Buffer
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	jpeg.Encode(&body, img, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/save?token="+token, &body)
+	req.Header.Set("Content-Type", "image/jpeg")
+	w := httptest.NewRecorder()
+	h.handleSave(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for expired token, got %d", w.Code)
+	}
+}
+
+func TestHandleSave_ContentTypeMismatch(t *testing.T) {
+	h := newTestHandler()
+
+	dir := t.TempDir()
+	token := h.prepareSave(filepath.Join(dir, "out.jpg"), "image/jpeg")
+
+	// Send PNG content-type but session expects JPEG.
+	var body bytes.Buffer
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	png.Encode(&body, img)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/save?token="+token, &body)
+	req.Header.Set("Content-Type", "image/png")
+	w := httptest.NewRecorder()
+	h.handleSave(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for content-type mismatch, got %d", w.Code)
+	}
+}
+
+func TestHandleSave_EmptyPayload(t *testing.T) {
+	h := newTestHandler()
+
+	dir := t.TempDir()
+	token := h.prepareSave(filepath.Join(dir, "out.jpg"), "image/jpeg")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/save?token="+token, bytes.NewReader(nil))
+	req.Header.Set("Content-Type", "image/jpeg")
+	w := httptest.NewRecorder()
+	h.handleSave(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for empty payload, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleSave_MethodNotAllowed(t *testing.T) {
+	h := newTestHandler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/save?token=foo", nil)
+	w := httptest.NewRecorder()
+	h.handleSave(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleImage
+// ---------------------------------------------------------------------------
+
+func TestHandleImage_WithToken(t *testing.T) {
+	h := newTestHandler()
+
+	// Register a real temporary file.
+	dir := t.TempDir()
+	imgPath := filepath.Join(dir, "test.jpg")
+	createTestJPEG(t, imgPath)
+
+	token := h.registerImageToken(imgPath)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/image?token="+token, nil)
+	w := httptest.NewRecorder()
+	h.handleImage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if w.Body.Len() == 0 {
+		t.Error("expected non-empty body")
+	}
+}
+
+func TestHandleImage_NoToken_NoImage(t *testing.T) {
+	h := newTestHandler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/image", nil)
+	w := httptest.NewRecorder()
+	h.handleImage(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestHandleImage_MethodNotAllowed(t *testing.T) {
+	h := newTestHandler()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/image", nil)
+	w := httptest.NewRecorder()
+	h.handleImage(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestHandleImage_InvalidToken(t *testing.T) {
+	h := newTestHandler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/image?token=nonexistent", nil)
+	w := httptest.NewRecorder()
+	h.handleImage(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleThumb
+// ---------------------------------------------------------------------------
+
+func TestHandleThumb_NoToken(t *testing.T) {
+	h := newTestHandler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/thumb", nil)
+	w := httptest.NewRecorder()
+	h.handleThumb(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestHandleThumb_MethodNotAllowed(t *testing.T) {
+	h := newTestHandler()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/thumb", nil)
+	w := httptest.NewRecorder()
+	h.handleThumb(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestHandleThumb_WithToken(t *testing.T) {
+	h := newTestHandler()
+
+	dir := t.TempDir()
+	imgPath := filepath.Join(dir, "test.jpg")
+	createTestJPEG(t, imgPath)
+
+	token := h.registerImageToken(imgPath)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/thumb?token="+token, nil)
+	w := httptest.NewRecorder()
+	h.handleThumb(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	ct := w.Header().Get("Content-Type")
+	if ct != "image/jpeg" {
+		t.Errorf("expected Content-Type image/jpeg, got %q", ct)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Middleware routing
+// ---------------------------------------------------------------------------
+
+func TestMiddleware_RoutesAPIRequests(t *testing.T) {
+	h := newTestHandler()
+
+	// The fallback handler records that it was called.
+	fallbackCalled := false
+	fallback := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fallbackCalled = true
+		w.WriteHeader(http.StatusTeapot) // easily distinguishable
+	})
+
+	mw := h.Middleware(fallback)
+
+	tests := []struct {
+		method  string
+		path    string
+		wantFallback bool
+	}{
+		{http.MethodGet, "/api/image", false},
+		{http.MethodGet, "/api/thumb", false},
+		{http.MethodPost, "/api/save", false},
+		{http.MethodGet, "/", true},
+		{http.MethodGet, "/index.html", true},
+		{http.MethodGet, "/other", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method+" "+tt.path, func(t *testing.T) {
+			fallbackCalled = false
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			w := httptest.NewRecorder()
+			mw.ServeHTTP(w, req)
+
+			if tt.wantFallback && !fallbackCalled {
+				t.Error("expected fallback handler to be called")
+			}
+			if !tt.wantFallback && fallbackCalled {
+				t.Error("expected API handler to be called, not fallback")
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// generateToken
+// ---------------------------------------------------------------------------
+
+func TestGenerateToken_Uniqueness(t *testing.T) {
+	seen := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		tok := generateToken()
+		if tok == "" {
+			t.Fatal("empty token")
+		}
+		if seen[tok] {
+			t.Fatalf("duplicate token on iteration %d", i)
+		}
+		seen[tok] = true
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Token consumed only once (handleSave)
+// ---------------------------------------------------------------------------
+
+func TestHandleSave_TokenConsumedOnce(t *testing.T) {
+	h := newTestHandler()
+
+	dir := t.TempDir()
+	savePath := filepath.Join(dir, "output.jpg")
+	token := h.prepareSave(savePath, "image/jpeg")
+
+	makeBody := func() io.Reader {
+		var buf bytes.Buffer
+		img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+		jpeg.Encode(&buf, img, nil)
+		return &buf
+	}
+
+	// First request succeeds.
+	req := httptest.NewRequest(http.MethodPost, "/api/save?token="+token, makeBody())
+	req.Header.Set("Content-Type", "image/jpeg")
+	w := httptest.NewRecorder()
+	h.handleSave(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("first save: expected 200, got %d", w.Code)
+	}
+
+	// Second request with same token should fail.
+	req2 := httptest.NewRequest(http.MethodPost, "/api/save?token="+token, makeBody())
+	req2.Header.Set("Content-Type", "image/jpeg")
+	w2 := httptest.NewRecorder()
+	h.handleSave(w2, req2)
+	if w2.Code != http.StatusBadRequest {
+		t.Errorf("second save: expected 400, got %d", w2.Code)
+	}
+}

--- a/handler_test.go
+++ b/handler_test.go
@@ -55,8 +55,12 @@ func TestRegisterImageToken_LRUEviction(t *testing.T) {
 	firstPath := filepath.Join("/tmp", "first.jpg")
 	firstToken := h.registerImageToken(firstPath)
 
-	// Fill up to the max (first entry is already registered, so start at 1).
-	for i := 1; i < maxImageTokens; i++ {
+	// Register the second path and record its token.
+	secondPath := filepath.Join("/tmp", "second.jpg")
+	secondToken := h.registerImageToken(secondPath)
+
+	// Fill up to the max.
+	for i := 2; i < maxImageTokens; i++ {
 		h.registerImageToken(fmt.Sprintf("/tmp/img_%04d.jpg", i))
 	}
 
@@ -64,16 +68,24 @@ func TestRegisterImageToken_LRUEviction(t *testing.T) {
 		t.Fatalf("expected %d tokens, got %d", maxImageTokens, len(h.imageTokens))
 	}
 
-	// Register one more — should evict the oldest (firstPath).
+	// Touch the first path again so it's the MOST recently used.
+	// This means the second path is now the LEAST recently used.
+	h.registerImageToken(firstPath)
+
+	// Register one more — should evict the oldest (secondPath now).
 	h.registerImageToken("/tmp/overflow.jpg")
 	if len(h.imageTokens) != maxImageTokens {
 		t.Fatalf("after overflow expected %d tokens, got %d", maxImageTokens, len(h.imageTokens))
 	}
 
-	// The evicted path should now yield a fresh token, not the original.
-	newToken := h.registerImageToken(firstPath)
-	if newToken == firstToken {
-		t.Error("expected oldest entry to be evicted and re-registered with a new token")
+	// The first path should still resolve to the original token because it was protected by LRU.
+	if h.registerImageToken(firstPath) != firstToken {
+		t.Error("expected first entry to be protected by LRU and return original token")
+	}
+
+	// The evicted second path should now yield a fresh token, not the original.
+	if h.registerImageToken(secondPath) == secondToken {
+		t.Error("expected second entry to be evicted and re-registered with a new token")
 	}
 }
 
@@ -183,7 +195,9 @@ func TestHandleSave_ContentTypeMismatch(t *testing.T) {
 	// Send PNG content-type but session expects JPEG.
 	var body bytes.Buffer
 	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
-	png.Encode(&body, img)
+	if err := png.Encode(&body, img); err != nil {
+		t.Fatal(err)
+	}
 
 	req := httptest.NewRequest(http.MethodPost, "/api/save?token="+token, &body)
 	req.Header.Set("Content-Type", "image/png")

--- a/handler_test.go
+++ b/handler_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"image"
 	"image/color"
 	"image/jpeg"
@@ -56,7 +57,7 @@ func TestRegisterImageToken_LRUEviction(t *testing.T) {
 
 	// Fill up to the max (first entry is already registered, so start at 1).
 	for i := 1; i < maxImageTokens; i++ {
-		h.registerImageToken(filepath.Join("/tmp", "img"+string(rune('A'+i%26))+string(rune('0'+i/26))+".jpg"))
+		h.registerImageToken(fmt.Sprintf("/tmp/img_%04d.jpg", i))
 	}
 
 	if len(h.imageTokens) != maxImageTokens {

--- a/settings_test.go
+++ b/settings_test.go
@@ -9,33 +9,58 @@ import (
 )
 
 func TestNormalizePathForCompare(t *testing.T) {
+	isCaseInsensitive := goruntime.GOOS == "darwin" || goruntime.GOOS == "windows"
+
 	tests := []struct {
 		name     string
 		input    string
-		expected string // Expected will depend on OS
+		expected string
 	}{
 		{
-			name:  "Clean path",
-			input: "/path/to/folder//subfolder/../",
-			// filepath.Clean("/path/to/folder//subfolder/../") -> "/path/to/folder"
+			name:     "Clean path",
+			input:    "/path/to/folder//subfolder/../",
+			expected: "/path/to/folder",
 		},
 		{
-			name:  "Case handling",
-			input: "/Path/To/Folder",
+			name:     "Already clean",
+			input:    "/usr/local/bin",
+			expected: "/usr/local/bin",
 		},
+		{
+			name:     "Trailing separator",
+			input:    "/path/to/folder/",
+			expected: "/path/to/folder",
+		},
+	}
+
+	// Case handling tests — expected differs by OS.
+	if isCaseInsensitive {
+		tests = append(tests, struct {
+			name     string
+			input    string
+			expected string
+		}{
+			name:     "Case insensitive OS lowercases",
+			input:    "/Path/To/Folder",
+			expected: "/path/to/folder",
+		})
+	} else {
+		tests = append(tests, struct {
+			name     string
+			input    string
+			expected string
+		}{
+			name:     "Case sensitive OS preserves case",
+			input:    "/Path/To/Folder",
+			expected: "/Path/To/Folder",
+		})
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := normalizePathForCompare(tt.input)
-
-			expectedBase := filepath.Clean(tt.input)
-			if goruntime.GOOS == "darwin" || goruntime.GOOS == "windows" {
-				expectedBase = strings.ToLower(expectedBase)
-			}
-
-			if result != expectedBase {
-				t.Errorf("normalizePathForCompare(%q) = %q, want %q", tt.input, result, expectedBase)
+			if result != tt.expected {
+				t.Errorf("normalizePathForCompare(%q) = %q, want %q", tt.input, result, tt.expected)
 			}
 		})
 	}
@@ -59,8 +84,12 @@ func TestSaveSettings_FolderValidation(t *testing.T) {
 	watchDir := filepath.Join(base, "watch")
 	exportDir := filepath.Join(base, "export")
 	childDir := filepath.Join(watchDir, "child")
-	os.MkdirAll(childDir, 0755)
-	os.MkdirAll(exportDir, 0755)
+	if err := os.MkdirAll(childDir, 0755); err != nil {
+		t.Fatalf("failed to create childDir: %v", err)
+	}
+	if err := os.MkdirAll(exportDir, 0755); err != nil {
+		t.Fatalf("failed to create exportDir: %v", err)
+	}
 
 	tests := []struct {
 		name        string

--- a/settings_test.go
+++ b/settings_test.go
@@ -152,11 +152,13 @@ func TestSaveSettings_FolderValidation(t *testing.T) {
 			settingsFile = tmpFile
 			defer func() { settingsFile = origFile }()
 
-			// Ensure currentSettings WatchFolder is blank so the watcher
-			// path in SaveSettings is never triggered (no handler needed).
+			// Set currentSettings.WatchFolder to tt.watch so that
+			// SaveSettings sees no WatchFolder change and does NOT call
+			// updateWatcher. This avoids starting a real fsnotify watcher
+			// (which would leak) when App.handler is nil.
 			settingsMu.Lock()
 			oldSettings := currentSettings
-			currentSettings.WatchFolder = ""
+			currentSettings.WatchFolder = tt.watch
 			settingsMu.Unlock()
 			defer func() {
 				settingsMu.Lock()

--- a/settings_test.go
+++ b/settings_test.go
@@ -59,8 +59,9 @@ func TestNormalizePathForCompare(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := normalizePathForCompare(tt.input)
-			if result != tt.expected {
-				t.Errorf("normalizePathForCompare(%q) = %q, want %q", tt.input, result, tt.expected)
+			expectedOS := filepath.FromSlash(tt.expected)
+			if result != expectedOS {
+				t.Errorf("normalizePathForCompare(%q) = %q, want %q", tt.input, result, expectedOS)
 			}
 		})
 	}

--- a/settings_test.go
+++ b/settings_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	goruntime "runtime"
+	"strings"
+	"testing"
+)
+
+func TestNormalizePathForCompare(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string // Expected will depend on OS
+	}{
+		{
+			name:  "Clean path",
+			input: "/path/to/folder//subfolder/../",
+			// filepath.Clean("/path/to/folder//subfolder/../") -> "/path/to/folder"
+		},
+		{
+			name:  "Case handling",
+			input: "/Path/To/Folder",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizePathForCompare(tt.input)
+
+			expectedBase := filepath.Clean(tt.input)
+			if goruntime.GOOS == "darwin" || goruntime.GOOS == "windows" {
+				expectedBase = strings.ToLower(expectedBase)
+			}
+
+			if result != expectedBase {
+				t.Errorf("normalizePathForCompare(%q) = %q, want %q", tt.input, result, expectedBase)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SaveSettings folder validation
+// ---------------------------------------------------------------------------
+
+// TestSaveSettings_FolderValidation tests the folder hierarchy checks in
+// App.SaveSettings. We use real temp directories so that filepath.EvalSymlinks
+// resolves correctly. The App has no handler and an empty WatchFolder, so the
+// watcher code path is safely skipped (WatchFolder doesn't change).
+func TestSaveSettings_FolderValidation(t *testing.T) {
+	// Create a directory tree:
+	//   root/
+	//     watch/
+	//     export/
+	//     watch/child/
+	base := t.TempDir()
+	watchDir := filepath.Join(base, "watch")
+	exportDir := filepath.Join(base, "export")
+	childDir := filepath.Join(watchDir, "child")
+	os.MkdirAll(childDir, 0755)
+	os.MkdirAll(exportDir, 0755)
+
+	tests := []struct {
+		name        string
+		watch       string
+		export      string
+		wantErrSub  string // substring expected in the error; empty = success
+	}{
+		{
+			name:       "same folder",
+			watch:      watchDir,
+			export:     watchDir,
+			wantErrSub: "same as the Watch folder",
+		},
+		{
+			name:       "export is child of watch",
+			watch:      watchDir,
+			export:     childDir,
+			wantErrSub: "subdirectory of the Watch folder",
+		},
+		{
+			name:       "watch is child of export",
+			watch:      childDir,
+			export:     watchDir,
+			wantErrSub: "subdirectory of the Export folder",
+		},
+		{
+			name:       "sibling directories (ok)",
+			watch:      watchDir,
+			export:     exportDir,
+			wantErrSub: "",
+		},
+		{
+			name:       "both empty (ok)",
+			watch:      "",
+			export:     "",
+			wantErrSub: "",
+		},
+		{
+			name:       "only watch set (ok)",
+			watch:      watchDir,
+			export:     "",
+			wantErrSub: "",
+		},
+		{
+			name:       "only export set (ok)",
+			watch:      "",
+			export:     exportDir,
+			wantErrSub: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := &App{}
+
+			// Temporarily override the settingsFile so saveSettings() doesn't
+			// clobber the user's real settings and doesn't fail.
+			origFile := settingsFile
+			tmpFile := filepath.Join(t.TempDir(), "settings.json")
+			settingsFile = tmpFile
+			defer func() { settingsFile = origFile }()
+
+			// Ensure currentSettings WatchFolder is blank so the watcher
+			// path in SaveSettings is never triggered (no handler needed).
+			settingsMu.Lock()
+			oldSettings := currentSettings
+			currentSettings.WatchFolder = ""
+			settingsMu.Unlock()
+			defer func() {
+				settingsMu.Lock()
+				currentSettings = oldSettings
+				settingsMu.Unlock()
+			}()
+
+			s := Settings{
+				WatchFolder:  tt.watch,
+				ExportFolder: tt.export,
+			}
+
+			result := app.SaveSettings(s)
+
+			if tt.wantErrSub == "" {
+				if result != "" {
+					t.Errorf("expected success, got error: %q", result)
+				}
+			} else {
+				if !strings.Contains(result, tt.wantErrSub) {
+					t.Errorf("expected error containing %q, got %q", tt.wantErrSub, result)
+				}
+			}
+		})
+	}
+}
+


### PR DESCRIPTION
- Add app_test.go: unit tests for formatFocalLength, formatAperture,
  formatShutterSpeed, gcd, parseFraction, extractXMPString,
  ensureValidExtension
- Add handler_test.go: HTTP handler tests for registerImageToken,
  prepareSave/handleSave lifecycle, handleImage, handleThumb,
  Middleware routing, generateToken, token single-use
- Extend settings_test.go: SaveSettings folder hierarchy validation
  (same folder, subdirectory detection, sibling dirs)
- Add types.test.ts: settingsKey mapping, toVisibility, applyVisibility,
  roundtrip consistency

resolved #127 