### PR TITLE
ci: add Codecov integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,6 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
       with:
-        file: ./coverage.txt
+        files: ./coverage.txt
         flags: backend
         name: backend-coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         npm run test:coverage
 
     - name: Upload Frontend Coverage to Codecov
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-latest' && secrets.CODECOV_TOKEN != ''
       uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -65,7 +65,7 @@ jobs:
         go build -v ./...
 
     - name: Upload Backend Coverage to Codecov
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-latest' && secrets.CODECOV_TOKEN != ''
       uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,8 @@ jobs:
         npm run test:coverage
 
     - name: Upload Frontend Coverage to Codecov
-      uses: codecov/codecov-action@v4
+      if: matrix.os == 'ubuntu-latest'
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         directory: ./frontend/coverage
@@ -64,7 +65,8 @@ jobs:
         go build -v ./...
 
     - name: Upload Backend Coverage to Codecov
-      uses: codecov/codecov-action@v4
+      if: matrix.os == 'ubuntu-latest'
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,9 @@ jobs:
         npm run test:coverage
 
     - name: Upload Frontend Coverage to Codecov
-      if: matrix.os == 'ubuntu-latest' && secrets.CODECOV_TOKEN != ''
-      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
+      if: matrix.os == 'ubuntu-latest'
+      uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         directory: ./frontend/coverage
         flags: frontend
         name: frontend-coverage
@@ -65,10 +64,9 @@ jobs:
         go build -v ./...
 
     - name: Upload Backend Coverage to Codecov
-      if: matrix.os == 'ubuntu-latest' && secrets.CODECOV_TOKEN != ''
-      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
+      if: matrix.os == 'ubuntu-latest'
+      uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.txt
         flags: backend
         name: backend-coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,23 @@ jobs:
         npm run build
         npm run test:coverage
 
+    - name: Upload Frontend Coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        directory: ./frontend/coverage
+        flags: frontend
+        name: frontend-coverage
+
     - name: Backend Build & Test (Go)
       run: |
-        go test -v ./...
+        go test -v -coverprofile=coverage.txt -covermode=atomic ./...
         go build -v ./...
+
+    - name: Upload Backend Coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.txt
+        flags: backend
+        name: backend-coverage

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,11 +3,11 @@ coverage:
     project:
       default:
         target: auto       # ベースコミットのカバレッジを目標にする
-        threshold: 2%      # 2%までの低下は許容する
+        threshold: 2       # 2%までの低下は許容する
     patch:
       default:
         target: auto
-        threshold: 2%
+        threshold: 2
 
 ignore:
   - "frontend/dist/**/*"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto       # ベースコミットのカバレッジを目標にする
+        threshold: 2%      # 2%までの低下は許容する
+    patch:
+      default:
+        target: auto
+        threshold: 2%
+
+ignore:
+  - "frontend/dist/**/*"
+  - "frontend/wailsjs/**/*"
+  - "build/**/*"
+  - "main.go"              # wails.Run など自動テストが困難なエントリーポイント


### PR DESCRIPTION
- Add codecov.yml to ignore frontend generated files and main.go
- Update ci.yml to generate coverage for Go and upload both Go and Frontend coverage reports to Codecov