### PR TITLE
fix: 常駐モードの動的切り替え対応とバックグラウンド起動問題の修正 

### DIFF
--- a/app.go
+++ b/app.go
@@ -48,6 +48,7 @@ type App struct {
 	handler *ImageHandler
 
 	// GUI state for dynamic system tray
+	trayMu     sync.Mutex
 	mainWindow *application.WebviewWindow
 	sysTray    *application.SystemTray
 	trayIcon   []byte
@@ -88,55 +89,65 @@ func (a *App) ServiceShutdown() error {
 	return nil
 }
 
-// SetupSystemTray creates the system tray icon and menu.
-func (a *App) SetupSystemTray() {
-	if a.sysTray != nil {
-		return // Already setup
-	}
-	app := application.Get()
-	
-	trayMenu := application.NewMenu()
-	trayMenu.Add("Show ExifFrame").OnClick(func(ctx *application.Context) {
-		if a.mainWindow != nil {
-			a.mainWindow.Show()
-			a.mainWindow.Focus()
+// SyncSystemTrayState synchronizes the system tray state with the current ResidentMode setting.
+func (a *App) SyncSystemTrayState() {
+	a.trayMu.Lock()
+	defer a.trayMu.Unlock()
+
+	settingsMu.RLock()
+	isResident := currentSettings.ResidentMode
+	settingsMu.RUnlock()
+
+	if isResident {
+		if a.sysTray != nil {
+			return // Already setup
 		}
-	})
-	trayMenu.Add("Preferences...").OnClick(func(ctx *application.Context) {
-		a.OpenSettingsWindow()
-	})
-	trayMenu.AddSeparator()
-	trayMenu.Add("Quit ExifFrame").OnClick(func(ctx *application.Context) {
-		app.Quit()
-	})
-
-	systray := app.SystemTray.New()
-	if goruntime.GOOS == "darwin" {
-		systray.SetTemplateIcon(a.trayIcon)
-	} else {
-		systray.SetIcon(a.trayIcon)
-	}
-	systray.SetMenu(trayMenu)
-	systray.SetTooltip("ExifFrame")
-
-	systray.OnClick(func() {
-		if a.mainWindow != nil {
-			if a.mainWindow.IsVisible() {
-				a.mainWindow.Hide()
-			} else {
+		app := application.Get()
+		
+		trayMenu := application.NewMenu()
+		trayMenu.Add("Show ExifFrame").OnClick(func(ctx *application.Context) {
+			if a.mainWindow != nil {
 				a.mainWindow.Show()
 				a.mainWindow.Focus()
 			}
-		}
-	})
-	a.sysTray = systray
-}
+		})
+		trayMenu.Add("Preferences...").OnClick(func(ctx *application.Context) {
+			a.OpenSettingsWindow()
+		})
+		trayMenu.AddSeparator()
+		trayMenu.Add("Quit ExifFrame").OnClick(func(ctx *application.Context) {
+			app.Quit()
+		})
 
-// RemoveSystemTray destroys the system tray icon if it exists.
-func (a *App) RemoveSystemTray() {
-	if a.sysTray != nil {
-		a.sysTray.Destroy()
-		a.sysTray = nil
+		systray := app.SystemTray.New()
+		if goruntime.GOOS == "darwin" {
+			systray.SetTemplateIcon(a.trayIcon)
+		} else {
+			systray.SetIcon(a.trayIcon)
+		}
+		systray.SetMenu(trayMenu)
+		systray.SetTooltip("ExifFrame")
+
+		systray.OnClick(func() {
+			if a.mainWindow != nil {
+				if a.mainWindow.IsVisible() {
+					a.mainWindow.Hide()
+				} else {
+					a.mainWindow.Show()
+					a.mainWindow.Focus()
+				}
+			}
+		})
+		a.sysTray = systray
+	} else {
+		if a.sysTray != nil {
+			if a.mainWindow != nil && !a.mainWindow.IsVisible() {
+				a.mainWindow.Show()
+				a.mainWindow.Focus()
+			}
+			a.sysTray.Destroy()
+			a.sysTray = nil
+		}
 	}
 }
 

--- a/app.go
+++ b/app.go
@@ -46,6 +46,11 @@ type App struct {
 
 	// handler is set after initialization so SaveImage can call prepareSave.
 	handler *ImageHandler
+
+	// GUI state for dynamic system tray
+	mainWindow *application.WebviewWindow
+	sysTray    *application.SystemTray
+	trayIcon   []byte
 }
 
 // NewApp creates a new App application struct
@@ -81,6 +86,58 @@ func (a *App) ServiceStartup(ctx context.Context, options application.ServiceOpt
 func (a *App) ServiceShutdown() error {
 	a.OnShutdown()
 	return nil
+}
+
+// SetupSystemTray creates the system tray icon and menu.
+func (a *App) SetupSystemTray() {
+	if a.sysTray != nil {
+		return // Already setup
+	}
+	app := application.Get()
+	
+	trayMenu := application.NewMenu()
+	trayMenu.Add("Show ExifFrame").OnClick(func(ctx *application.Context) {
+		if a.mainWindow != nil {
+			a.mainWindow.Show()
+			a.mainWindow.Focus()
+		}
+	})
+	trayMenu.Add("Preferences...").OnClick(func(ctx *application.Context) {
+		a.OpenSettingsWindow()
+	})
+	trayMenu.AddSeparator()
+	trayMenu.Add("Quit ExifFrame").OnClick(func(ctx *application.Context) {
+		app.Quit()
+	})
+
+	systray := app.SystemTray.New()
+	if goruntime.GOOS == "darwin" {
+		systray.SetTemplateIcon(a.trayIcon)
+	} else {
+		systray.SetIcon(a.trayIcon)
+	}
+	systray.SetMenu(trayMenu)
+	systray.SetTooltip("ExifFrame")
+
+	systray.OnClick(func() {
+		if a.mainWindow != nil {
+			if a.mainWindow.IsVisible() {
+				a.mainWindow.Hide()
+			} else {
+				a.mainWindow.Show()
+				a.mainWindow.Focus()
+			}
+		}
+	})
+	a.sysTray = systray
+}
+
+// RemoveSystemTray destroys the system tray icon if it exists.
+func (a *App) RemoveSystemTray() {
+	if a.sysTray != nil {
+		a.sysTray.Destroy()
+		a.sysTray = nil
+	}
 }
 
 // getCurrentImagePath returns the path of the currently loaded image in a thread-safe manner.

--- a/app.go
+++ b/app.go
@@ -129,6 +129,12 @@ func (a *App) SyncSystemTrayState() {
 		systray.SetTooltip("ExifFrame")
 
 		systray.OnClick(func() {
+			a.trayMu.Lock()
+			defer a.trayMu.Unlock()
+			// Skip if tray was destroyed concurrently
+			if a.sysTray == nil {
+				return
+			}
 			if a.mainWindow != nil {
 				if a.mainWindow.IsVisible() {
 					a.mainWindow.Hide()
@@ -148,6 +154,25 @@ func (a *App) SyncSystemTrayState() {
 			a.sysTray.Destroy()
 			a.sysTray = nil
 		}
+	}
+}
+
+// HandleWindowClosing intercepts the window close event and manages the application lifecycle
+// in coordination with the resident mode setting.
+func (a *App) HandleWindowClosing(win *application.WebviewWindow, e *application.WindowEvent) {
+	a.trayMu.Lock()
+
+	settingsMu.RLock()
+	isResident := currentSettings.ResidentMode
+	settingsMu.RUnlock()
+
+	if isResident {
+		win.Hide()
+		e.Cancel()
+		a.trayMu.Unlock()
+	} else {
+		a.trayMu.Unlock()
+		application.Get().Quit()
 	}
 }
 

--- a/frontend/src/SettingsWindow.tsx
+++ b/frontend/src/SettingsWindow.tsx
@@ -250,7 +250,7 @@ function SettingsWindow() {
                                     />
                                     Keep running in system tray
                                 </label>
-                                <small style={{ display: 'block', marginTop: '0.5rem', marginLeft: '1.5rem', color: 'var(--text-secondary)', textAlign: 'left' }}>When enabled, closing the window keeps ExifFrame running in the menu bar. Changes take effect after restarting the app.</small>
+                                <small style={{ display: 'block', marginTop: '0.5rem', marginLeft: '1.5rem', color: 'var(--text-secondary)', textAlign: 'left' }}>When enabled, closing the window keeps ExifFrame running in the menu bar.</small>
                             </div>
                         </div>
                     )}

--- a/main.go
+++ b/main.go
@@ -140,20 +140,7 @@ func main() {
 	// --- System Tray (Resident Mode) ---
 	// Intercept window close: hide instead of destroy, unless setting changed dynamically.
 	win.RegisterHook(events.Common.WindowClosing, func(e *application.WindowEvent) {
-		if isQuitting.Load() {
-			return
-		}
-
-		settingsMu.RLock()
-		isResident := currentSettings.ResidentMode
-		settingsMu.RUnlock()
-
-		if isResident {
-			win.Hide()
-			e.Cancel()
-		} else {
-			application.Get().Quit()
-		}
+		appStruct.HandleWindowClosing(win, e)
 	})
 
 	appStruct.SyncSystemTrayState()

--- a/main.go
+++ b/main.go
@@ -83,10 +83,10 @@ func main() {
 	handler := NewImageHandler(appStruct)
 	appStruct.handler = handler
 
-	// Read resident mode setting (read once at startup; changes require restart).
-	settingsMu.RLock()
-	residentMode := currentSettings.ResidentMode
-	settingsMu.RUnlock()
+	// Read settings (if needed later)
+	// settingsMu.RLock()
+	// residentMode := currentSettings.ResidentMode
+	// settingsMu.RUnlock()
 
 	app := application.New(application.Options{
 		Name:        "ExifFrame",
@@ -156,9 +156,7 @@ func main() {
 		}
 	})
 
-	if residentMode {
-		appStruct.SetupSystemTray()
-	}
+	appStruct.SyncSystemTrayState()
 
 	err := app.Run()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -99,7 +99,7 @@ func main() {
 			Middleware: handler.Middleware,
 		},
 		Mac: application.MacOptions{
-			ApplicationShouldTerminateAfterLastWindowClosed: !residentMode,
+			ApplicationShouldTerminateAfterLastWindowClosed: false,
 		},
 		ShouldQuit: func() bool {
 			isQuitting.Store(true)
@@ -134,49 +134,30 @@ func main() {
 		}
 	})
 
+	appStruct.mainWindow = win
+	appStruct.trayIcon = trayIcon
+
 	// --- System Tray (Resident Mode) ---
-	if residentMode {
-		// Intercept window close: hide instead of destroy.
-		win.RegisterHook(events.Common.WindowClosing, func(e *application.WindowEvent) {
-			if isQuitting.Load() {
-				return
-			}
+	// Intercept window close: hide instead of destroy, unless setting changed dynamically.
+	win.RegisterHook(events.Common.WindowClosing, func(e *application.WindowEvent) {
+		if isQuitting.Load() {
+			return
+		}
+
+		settingsMu.RLock()
+		isResident := currentSettings.ResidentMode
+		settingsMu.RUnlock()
+
+		if isResident {
 			win.Hide()
 			e.Cancel()
-		})
-
-		// Build tray right-click menu.
-		trayMenu := application.NewMenu()
-		trayMenu.Add("Show ExifFrame").OnClick(func(ctx *application.Context) {
-			win.Show()
-			win.Focus()
-		})
-		trayMenu.Add("Preferences...").OnClick(func(ctx *application.Context) {
-			appStruct.OpenSettingsWindow()
-		})
-		trayMenu.AddSeparator()
-		trayMenu.Add("Quit ExifFrame").OnClick(func(ctx *application.Context) {
-			application.Get().Quit()
-		})
-
-		systray := app.SystemTray.New()
-		if runtime.GOOS == "darwin" {
-			systray.SetTemplateIcon(trayIcon) // Auto-adapts to dark/light mode on macOS
 		} else {
-			systray.SetIcon(trayIcon)
+			application.Get().Quit()
 		}
-		systray.SetMenu(trayMenu)
-		systray.SetTooltip("ExifFrame")
+	})
 
-		// Left-click toggles main window visibility.
-		systray.OnClick(func() {
-			if win.IsVisible() {
-				win.Hide()
-			} else {
-				win.Show()
-				win.Focus()
-			}
-		})
+	if residentMode {
+		appStruct.SetupSystemTray()
 	}
 
 	err := app.Run()

--- a/settings.go
+++ b/settings.go
@@ -230,6 +230,10 @@ func (a *App) SaveSettings(s Settings) string {
 		if s.ResidentMode {
 			a.SetupSystemTray()
 		} else {
+			if a.mainWindow != nil && !a.mainWindow.IsVisible() {
+				a.mainWindow.Show()
+				a.mainWindow.Focus()
+			}
 			a.RemoveSystemTray()
 		}
 	}

--- a/settings.go
+++ b/settings.go
@@ -225,5 +225,14 @@ func (a *App) SaveSettings(s Settings) string {
 			return "Error: Failed to start watcher: " + err.Error()
 		}
 	}
+	
+	if oldSettings.ResidentMode != s.ResidentMode {
+		if s.ResidentMode {
+			a.SetupSystemTray()
+		} else {
+			a.RemoveSystemTray()
+		}
+	}
+
 	return "" // Success
 }

--- a/settings.go
+++ b/settings.go
@@ -227,15 +227,7 @@ func (a *App) SaveSettings(s Settings) string {
 	}
 	
 	if oldSettings.ResidentMode != s.ResidentMode {
-		if s.ResidentMode {
-			a.SetupSystemTray()
-		} else {
-			if a.mainWindow != nil && !a.mainWindow.IsVisible() {
-				a.mainWindow.Show()
-				a.mainWindow.Focus()
-			}
-			a.RemoveSystemTray()
-		}
+		a.SyncSystemTrayState()
 	}
 
 	return "" // Success


### PR DESCRIPTION
## 概要
「Keep running in system tray」のチェックを外しても、ウィンドウを閉じた際にアプリがバックグラウンドで動き続けてしまう問題を修正
また、この修正に合わせて常駐モードの設定変更を **アプリの再起動なしで即座に反映（動的トレイ生成・破棄）** できるようにUXを大幅に改善

## 変更内容
- **ウィンドウ終了制御の動的化 (`main.go`)**: 
  - OS任せの終了制御（`ApplicationShouldTerminateAfterLastWindowClosed`）への依存を廃止し、自前で `events.Common.WindowClosing` フックを用いて「ウィンドウを隠すか、アプリを終了するか」を動的に判定するように修正
- **システムトレイの動的生成・破棄 (`app.go`, `settings.go`)**: 
  - 設定保存時に `ResidentMode` の変更を検知し、ONになった場合は即座にトレイアイコンを生成（`SetupSystemTray`）、OFFになった場合は即座に破棄（`RemoveSystemTray`）するロジックを追加
- **操作不能状態（ヘッドレス化）の防止 (`settings.go`)**:
  - メインウィンドウを隠している状態で、トレイから設定画面（Preferences）を開いて常駐モードをOFFにした際、トレイが消えてアプリを操作できなくなる問題への対策として、トレイ破棄前にメインウィンドウが非表示であれば再表示(`Show` / `Focus`)するように対応
- **UI文言の整理 (`SettingsWindow.tsx`)**:
  - 動的反映が可能になったため、「Changes take effect after restarting the app.」の注意書きを削除

Fixes #148 